### PR TITLE
Update docs to show link to 0.2.4

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -1,5 +1,4 @@
 
-
 <!DOCTYPE html>
 
 
@@ -152,7 +151,8 @@
 <p>Below are links to the documentation for all versions of Astropy.</p>
 <ul class="simple">
 <li><a class="reference external" href="http://devdocs.astropy.org">Latest developer version</a></li>
-<li><a class="reference external" href="https://astropy.readthedocs.org/en/v0.2.3/index.html">v0.2.3 (Current Stable Version)</a></li>
+<li><a class="reference external" href="https://astropy.readthedocs.org/en/v0.2.4/index.html">v0.2.4 (Current Stable Version)</a></li>
+<li><a class="reference external" href="https://astropy.readthedocs.org/en/v0.2.3/index.html">v0.2.3</a></li>
 <li><a class="reference external" href="https://astropy.readthedocs.org/en/v0.2.2/index.html">v0.2.2</a></li>
 <li><a class="reference external" href="https://astropy.readthedocs.org/en/v0.2.1/index.html">v0.2.1</a></li>
 <li><a class="reference external" href="https://astropy.readthedocs.org/en/v0.2/index.html">v0.2</a></li>


### PR DESCRIPTION
It seems outdated. It still points that the current stable version is v0.2.3. I added the v0.2.4.
