### PR TITLE
Add gammapy to affiliated package registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -100,6 +100,7 @@
         {
             "name": "gammapy",
             "maintainer": "Christoph Deil <Deil.Christoph@gmail.com>",
+            "provisional": "2015-2-27",
             "stable": false,
             "home_url": "https://github.com/gammapy/gammapy",
             "repo_url": "http://github.com/gammapy/gammapy.git",


### PR DESCRIPTION
This is a port of @cdeil's astropy/old-astropy-website-src#47 to the new web site, which is now to be edited directly in this repository.
