### PR TITLE
Add Fink to the package managers list for OSX

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 
 			<div id="osx">
 				<p>There are a number of options for installing the astropy package on MacOS X. Astropy can be installed using the
-					<a href="http://www.macports.org/">MacPorts</a> package manager,
+					<a href="http://www.macports.org/">MacPorts</a> or <a href="http://www.finkproject.org/">Fink</a> package managers,
 					and is also included by default in the
 					<a href="https://store.continuum.io/cshop/anaconda/">Anaconda Python Distribution</a> (more details <a href="http://astropy.readthedocs.org/en/stable/install.html#anaconda-python-distribution">here</a>),
 					<a href="https://www.enthought.com/products/canopy/">Enthought Canopy</a>, and


### PR DESCRIPTION
Astropy is also available as a [Fink package](http://pdb.finkproject.org/pdb/package.php/astropy-py33) on OSX.
