### PR TITLE
Fix hash links going to tabs on index page

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -27,11 +27,13 @@ $( document ).ready(function(){
     $('#os-selector ul').each(function(){
       // For each set of tabs, we want to keep track of
       // which tab is active and it's associated content
-      var $active, $content, $links = $(this).find('a');
+      var hash, $active, $content, $links = $(this).find('a');
 
       // If the location.hash matches one of the links, use that as the active tab.
+      // If no location.hash is given, use a tab determined by guess_os()
       // If no match is found, use the first link as the initial active tab.
-      $active = $($links.filter('[href="'+location.hash+'"]')[0] || $links[0]);
+      hash = (location.hash == "") ? '#' + guess_os() : location.hash;
+      $active = $($links.filter('[href="'+hash+'"]')[0] || $links[0]);
       $active.addClass('active');
       $content = $($active.attr('href'));
 
@@ -83,9 +85,6 @@ $( document ).ready(function(){
             });
         });
     });
-
-    $("[href='#" + guess_os() + "']").trigger('click');
-
 }); // Document Ready
 
 


### PR DESCRIPTION
As discussed in #15, It turns out #4 had the unintended side effect of overriding the initial tab, even if it's given as a hash - e.g. `astropy.org/index.html#dev` would still go to whatever your OS is, instead of the developer docs.  This adjust the javascript to prevent this from happening.

It also has a few random clean-ups in functions.js, mostly because my editor sanitizes whitespace automatically.

cc @astrofrog @kayleanelson 
