### PR TITLE
fixed feedback link to point to something appropriate to the new page structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,10 +165,10 @@
 		If you run into any issues when using
 		Astropy, please report them using the
 		<a href="https://github.com/astropy/astropy/issues">issue tracker</a>.
-		Finally, If
-		you have any questions regarding using Astropy, or have feedback on how we
-		can improve the package, please head over to our <a
-		href="feedback">feedback</a> page.</p>
+		Finally, If you have any questions regarding using Astropy, or have feedback on how we
+		can improve the package, please head over to our 
+		<a href="contribute.html">feedback and contributing</a> or 
+		<a href="help.html">help</a> pages.</p>
 
 		<a class="button" href="contribute.html" target="_blank">Contribute feedback or code</a>
 		<a class="button" href="https://github.com/astropy/astropy/issues" target="_blank">Report issues</a>


### PR DESCRIPTION
Reported in astropy/astropy#2299 - the former "feedback" page was missing.  The relevant text has been changed to reflect the new page structure.

I'll also update the `feedback.astropy.org` subdomain to point to a real page.
