### PR TITLE
Fix link to development version docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
 			<a class="button" href="http://docs.astropy.org" target="_blank">Current Documentation</a>
 			<span class="button">Other Docs ▼</span>
 			<ul class="dropdown">
-				<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+				<li><a href="https://astropy.readthedocs.org/en/latest/index.html" target="_blank">In Development</a></li>
+				<li><a href="https://astropy.readthedocs.org/en/v0.3.2/index.html" target="_blank">v0.3.2</a></li>
 				<li><a href="https://astropy.readthedocs.org/en/v0.3.1/index.html" target="_blank">v0.3.1</a></li>
 				<li><a href="https://astropy.readthedocs.org/en/v0.3/index.html" target="_blank">v0.3</a></li>
 				<li><a href="https://astropy.readthedocs.org/en/v0.2.5/index.html" target="_blank">v0.2.5</a></li>


### PR DESCRIPTION
@astrofrog For me http://devdocs.astropy.org/ doesn't work any more, so I change the link to directly point to the readthedocs page.

I also added 0.3.2 which was missing in the list of old versions.
