### PR TITLE
Add 0.4 announcement

### DIFF
--- a/announcements/release-0.4.html
+++ b/announcements/release-0.4.html
@@ -79,7 +79,7 @@ In addition, hundreds of smaller improvements and fixes have been made. An overv
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://docs.astropy.org/en/latest/whatsnew/0.4.html">http://docs.astropy.org/en/latest/whatsnew/0.4.html</a>
 </p>
 <p>
-Instructions for installing Astropy are provided at the http://www.astropy.org website, and extensive documentation can be found at:
+Instructions for installing Astropy are provided on our <a href="http://www.astropy.org">website</a>, and extensive documentation can be found at:
 </p>
 <p>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://docs.astropy.org">http://docs.astropy.org</a>


### PR DESCRIPTION
@eteq - I've had requests in the past for a nicely formatted version of the announcement that we can e.g. tweet or post to facebook rather than linking to the mailing list view (we still send the normal email to the mailing lists, but for twitter we can tweet this page). We don't have to link to this from anywhere in the actual website, but do you have any objections to this?
