### PR TITLE
add imexam as affiliated package

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -115,6 +115,7 @@
 		<li><a href="http://dev.usvao.org/vao/wiki/Products/PyVO" target="_blank">PyVO</a>: Access to the Virtual Observatory through Python</li>
 		<li><a href="https://github.com/gammapy/gammapy" target="_blank">gammapy</a>: A high level gamma-ray astronomy data analysis package.</li>
 		<li><a href="https://github.com/astropy/ccdproc" target="_blank">ccdproc</a>: package for CCD data reductions</li>
+		<li><a href="https://github.com/spacetelescope/imexam" target="_blank">imexam</a>: A package for functionality like IRAF's imexamine</li>
 	</ul>
 
 	<p>These packages are still very much in development, and the user interface (API) may not be stable. If you do try these packages, please do report any issues to the developers.</p>

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -142,7 +142,7 @@
             "stable": false,
             "home_url": "http://imexam.readthedocs.org/imexam/index.html",
             "repo_url": "http://github.com/spacetelescope/imexam",
-            "pypi_name": ""
+            "pypi_name": "imexam"
         }
     ]
 }

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -134,6 +134,15 @@
             "home_url": "https://github.com/astropy/pyregion",
             "repo_url": "https://github.com/astropy/pyregion.git",
             "pypi_name": "pyregion"
+        },
+        {
+            "name": "imexam",
+            "maintainer": "Megan Soey",
+            "provisional": "2015-07-30",
+            "stable": false,
+            "home_url": "http://imexam.readthedocs.org/imexam/index.html",
+            "repo_url": "http://github.com/spacetelescope/imexam",
+            "pypi_name": ""
         }
     ]
 }


### PR DESCRIPTION
This does just what it says: adds `imexam` to the registry of affiliated packages.

A few questions for @sosey before this is ready to be merged: 

1. I've classified this as "not stable", which just means that it's under active development.  Do you agree with that, or do you think it should be considered "stable".
2. Is there a PyPI entry?  Would you be willing to put it up there so people can ``pip install`` it?  It's fine if it's just an initial "development version".
3. You've had a chance to look over the description at the bottom of http://affiliated.astropy.org, right? So you know what I mean here by "provisional"?

cc @astrofrog 