### PR TITLE
Add section about the license to about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -208,6 +208,13 @@
 
 	</section>
 
+	<section>
+		<a name="license"></a>
+
+		<h2>License</h2>
+
+		<p>Astropy is licensed under a <a href="http://opensource.org/licenses/BSD-3-Clause">three-clause BSD license</a>.  For details, see the <a href="https://github.com/astropy/astropy/blob/master/licenses/LICENSE.rst" target="_blank">licenses/LICENSE.rst</a> file in the astropy repository.</p>
+	</section>
 	
 
 	<footer>


### PR DESCRIPTION
In response to astropy/astropy#2908, this adds a brief section in the about page that specifies what astropy's license is.
