### PR TITLE
Dotastro ack updates

### DIFF
--- a/about.html
+++ b/about.html
@@ -78,6 +78,20 @@
 
 		<p>The logo is also available <a href="http://www.astropy.org/_downloads/astropy_powered.png">with white text</a>, or the SVG originals can be obtained at the <a href="http://github.com/astropy/astropy-logo" target="_blank">astropy-logo github repository.</a></p>
 
+		<h3>In Projects</h3>
+
+		<p>If you are using Astropy as part of a code project (e.g., affiliated packages), a useful way to acknowledge your use of Astropy is with a badge in your README. We suggest this badge: </p>
+
+		
+
+		<img src="http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat" alt="Powered by Astropy Badge"/>
+
+		<p> Which is available at the URL <cite>http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat</cite>. If your code is hosted on github, You can place the following in your README.md file to get the badge:</p>
+
+
+		<cite>[![astropy](http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat)](http://www.astropy.org/)</cite>
+
+
 	</section>
 
 

--- a/about.html
+++ b/about.html
@@ -62,12 +62,13 @@
 
 		<h3>In Publications</h3>
 
-		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we would be grateful if you could include the following acknowledgment:</p>
+		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you cite the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> - 
+		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).
+        We provide the following as a standard  acknowledgment you can use if there is not a specific place to cite the paper:</p>
 
 		<p class="citation"><cite>This research made use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2013).</cite></p>
 
-		<p>where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> - 
-		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>). If you wish, you can also include a link to <cite>http://www.astropy.org</cite> (if the journal allows this) in addition to the above text.</p>
+		<p>If you wish, you can also include a link to <cite>http://www.astropy.org</cite> (if the journal allows this) in addition to the above text.</p>
 
 		<h3>In Presentations</h3>
 


### PR DESCRIPTION
This implements two things that came out of discussions at the .Astronomy 6 conference:

* A more firm/direct wording about citing the astropy paper
* A mention of how to use badges for projects that use Astropy (closes #48 )

cc @astrofrog 