### PR TITLE
update index to v1.0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,13 +56,14 @@
 			<span class="button">Other Docs ▼</span>
 			<ul class="dropdown">
 				<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+				<li><a href="https://astropy.readthedocs.org/en/v1.0/index.html" target="_blank">v1.0</a></li>
 				<li><a href="https://astropy.readthedocs.org/en/v0.4.5/index.html" target="_blank">v0.4.5</a></li>
 				<li><a href="https://astropy.readthedocs.org/en/v0.3.2/index.html" target="_blank">v0.3.2</a></li>
 				<li><a href="https://astropy.readthedocs.org/en/v0.2.5/index.html" target="_blank">v0.2.5</a></li>
 				<li><a href="https://astropy.readthedocs.org/en/v0.1/index.html" target="_blank">v0.1</a></li>
 			</ul>
 		</div>
-		<p class="version">Current Version: 1.0</p>
+		<p class="version">Current Version: 1.0.1</p>
 		<p class="acknowledge">Please remember to <a href="about.html#acknowledge">acknowledge</a> the use of Astropy!</a></p>
 	</section>
 


### PR DESCRIPTION
This just updates index.html to reflect that 1.0.1 is out, rather than saying the latest is 1.0

I also updated the stable branch in the main repo to be v1.0.1 and set readthedocs to build a version for 1.0.1.  @embray, can you try to ping me (or @astrofrog) with a reminder to do the RTD stuff when you do bugfix releases?  That makes it easier to keep the stuff tightly in sync.

This is pretty trivial so I'll merge it immediately to keep things up-to-date, but I thought I should PR it just to make sure the record is there.