### PR TITLE
Add gwcs to affiliated package registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -152,6 +152,15 @@
             "home_url": "https://spacetelescope.github.io/sphere/spherical_geometry/",
             "repo_url": "https://github.com/spacetelescope/sphere.git",
             "pypi_name": "spherical-geometry"
+        },
+        {
+            "name": "gwcs",
+            "maintainer": "Nadia Dencheva",
+            "provisional": false,
+            "stable": false,
+            "home_url": "http://gwcs.readthedocs.org/en/latest/",
+            "repo_url": "https://github.com/spacetelescope/gwcs.git",
+            "pypi_name": "gwcs"
         }
     ]
 }


### PR DESCRIPTION
This PR adds `gwcs` to the affiliated package registry to make it easier to find.

@eteq @astrofrog – OK?

@nden – You should register the name `gwcs` on PyPI to make sure it's still available when you want to make a release.