### PR TITLE
Added glue as an affiliated package

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -127,6 +127,15 @@
             "pypi_name": "wcsaxes"
         },
         {
+            "name": "Glue",
+            "maintainer": "Chris Beaumont and Thomas Robitaille <thomas.robitaille@gmail.com>",
+            "provisional": "2016-04-27",
+            "stable": true,
+            "home_url": "https://www.glue-viz.org",
+            "repo_url": "https://github.com/glue-viz/glue.git",
+            "pypi_name": "glueviz"
+        },
+        {
             "name": "pyregion",
             "maintainer": "Jae-Joon Lee",
             "provisional": "2016-02-22",


### PR DESCRIPTION
Based on an email discussion a little while back with @ChrisBeaumont and @perrygreenfield, I think we agreed that glue should be an affiliated package. I think this is a good time to make sure we also understand what the implications of being an affiliated package are. So just to be clear, listing glue as an affiliated package does not exclude having it also be affiliated with other projects (e.g. outside astronomy), correct? In my view, the key sentence is the following (from our website):

> ... but has requested to be included as part of the Astropy project’s community. **These packages are expressing an interest in Astropy’s goals of improving reuse, interoperability, and interface standards for python astronomy and astrophysics packages.**

Because glue is also intended for use outside astronomy, so we need to be sure that being affiliated does not mean that glue is 'part' of the Astropy project as such. I guess we could try and make these kinds of points clearer on the website to avoid discouraging people from becoming 'affiliated'?