### PR TITLE
Fix astropy logo so that index page matches other pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 		    <a id="responsive-menu-button" href="#sidr-main"><div><svg senable-background="new 0 0 24 24" height="24px" id="Layer_1" version="1.1" viewBox="0 0 24 24" width="24px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g><g><path d="M23.244,17.009H0.75c-0.413,0-0.75,0.36-0.75,0.801v3.421C0,21.654,0.337,22,0.75,22h22.494c0.414,0,0.75-0.346,0.75-0.77    V17.81C23.994,17.369,23.658,17.009,23.244,17.009z M23.244,9.009H0.75C0.337,9.009,0,9.369,0,9.81v3.421    c0,0.424,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.345,0.75-0.769V9.81C23.994,9.369,23.658,9.009,23.244,9.009z     M23.244,1.009H0.75C0.337,1.009,0,1.369,0,1.81V5.23c0,0.423,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.346,0.75-0.769V1.81    C23.994,1.369,23.658,1.009,23.244,1.009z"/></g></g></svg></div></a>
 		    <!-- -->
 		</div>
-		<a href="index.html"><img src="images/astropy_word.svg" width="91" onerror="this.src='images/astropy_word_32.png; this.onerror=null;"/></a>
+		<a href="index.html"><img src="images/astropy_word.svg" height="32" onerror="this.src='images/astropy_word_32.png; this.onerror=null;"/></a>
 		<div id="navigation">
 			<ul>
 				<li><a href="about.html">About</a></li>


### PR DESCRIPTION
In master right now (and hence on the astropy.org site), the front page and all the other pages have slightly different sized "astropy" text (in the upper-left corner). This PR adjusts it so that they're all the same.

@mdboom - the git history says you set this up as part of #58 - was there some reason this was supposed to be different, or was this just an oversight?