### PR TITLE
Add galpy to registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -161,6 +161,15 @@
             "home_url": "http://gwcs.readthedocs.org/en/latest/",
             "repo_url": "https://github.com/spacetelescope/gwcs.git",
             "pypi_name": "gwcs"
+        },
+        {
+            "name": "galpy",
+            "maintainer": "Jo Bovy",
+            "provisional": false,
+            "stable": true,
+            "home_url": "http://galpy.readthedocs.org/en/latest/",
+            "repo_url": "https://github.com/jobovy/galpy",
+            "pypi_name": "galpy"
         }
     ]
 }


### PR DESCRIPTION
I'd like to explore what it would take to make galpy an affiliated package (something I have been discussing in the past with @eteq). 

galpy is a well-tested, well-documented python package for galactic dynamics. It supports orbit integration in a variety of potentials, evaluating and sampling various distribution functions, the calculation of action-angle coordinates for all static potentials, and some support for handling the outputs of numerical simulations. Overall, galpy consists of about 54,000 lines, including 23,000 lines of code in the module, 11,000 lines of test code, and about 20,000 lines of documentation. The test suite covers 99.6% of the code. galpy is a stable package and is described in [this paper](http://adsabs.harvard.edu/abs/2015ApJS..216...29B) with full documentation at [this URL](http://galpy.readthedocs.org/en/latest/).

It's not entirely clear to me how to best make use of existing Astropy functionality in galpy. I have started a branch [galpy/apy](https://github.com/jobovy/galpy/tree/apy) for any necessary changes. The first (and so far only) functionality I have added is to be able to output positions along an integrated orbit as a SkyCoord objects. galpy contains a bunch of custom, fast coordinate transformation methods that somewhat duplicate the functionality in the SkyCoord class (but certainly not entirely). While these functions could be made to accept SkyCoord instances as inputs, there does not seem to be too much point to that, but I'd be open to suggestions on how this could be done. If astropy had support for transformations of proper motions, velocities, and their errors, one could imagine replacing my whole coordinate-transformation module with that, but I don't think that this is the case currently.

I plan to soon release a v1.1 of galpy, which would incorporate the changes in the [galpy/apy](https://github.com/jobovy/galpy/tree/apy) branch.