### PR TITLE
Add python-cpl to affiliated packages

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -200,6 +200,16 @@
             "home_url": "http://spectral-cube.rtfd.org",
             "repo_url": "https://github.com/radio-astro-tools/spectral-cube",
             "pypi_name": "spectral-cube"
+        },
+        {
+            "name": "python-cpl",
+            "maintainer": "Adam Ginsburg",
+            "provisional": false,
+            "stable": false,
+            "home_url": "http://python-cpl.readthedocs.org/en/latest/",
+            "repo_url": "https://github.com/olebole/python-cpl",
+            "pypi_name": "python-cpl",
+            "description": "Framework to process ESO pipelines for the VLT instruments."
         }
     ]
 }

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -203,7 +203,7 @@
         },
         {
             "name": "python-cpl",
-            "maintainer": "Ole streicher",
+            "maintainer": "Ole Streicher",
             "provisional": false,
             "stable": false,
             "home_url": "http://python-cpl.readthedocs.org/en/latest/",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -203,7 +203,7 @@
         },
         {
             "name": "python-cpl",
-            "maintainer": "Adam Ginsburg",
+            "maintainer": "Ole streicher",
             "provisional": false,
             "stable": false,
             "home_url": "http://python-cpl.readthedocs.org/en/latest/",


### PR DESCRIPTION
Hi,

I am the author of the python package "python-cpl". This package is basically a small framework to process [ESO pipelines for the VLT instruments](http://www.eso.org/sci/software/pipelines/).

 * The package uses astropy.io.fits for the file handling.
 * documentation is available
 * CI tests cover ~90% of the code

URLs:
 * [PyPI](https://pypi.python.org/pypi/python-cpl)
 * [Documentation](http://python-cpl.readthedocs.org/)
 * [Github](https://github.com/olebole/python-cpl)
 * [Travis](https://travis-ci.org/olebole/python-cpl)

I would like to ask whether the package could get the status of an Astropy affiliated package. I will also post this on the astropy-dev mailing list.

Best regards

Ole
