### PR TITLE
add py3.x requirement for affiliated package standards

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -186,6 +186,8 @@
 		<li>The package developer(s) should make an effort to connect with the Astropy developer community, including developers from  the core astropy package or any related affiliated packages.</li>
 
 		<li>While not a strict requirement, we also provide <a href="http://docs.astropy.org/en/stable/development/codeguide.html">coding guidelines</a> that will make your code easier to read by members of the community.</li>
+
+		<li>We strongly encourage affiliated packages be compatible with Python 3.x. Tips for how to acheive this are given in the <a href="http://docs.astropy.org/en/stable/development/codeguide.html#writing-portable-code-for-python-2-and-3"> revelant section of the coding guidelines</a>. The recommended route is to use <a href="http://pythonhosted.org/six/">six</a>, which can be imported as "<code>from astropy.extern import six</code>" to avoid introducing an explicit dependency on six.</li>
 	</ul>
 	</p>
 

--- a/css/style.css
+++ b/css/style.css
@@ -54,6 +54,10 @@ body{
 	font-family: 'Open Sans', sans-serif;
 }
 
+code {
+	font-family: monospace;
+}
+
 /* This file is in the public domain because it was created by NASA
 and ESA.  The material was created for NASA by Space Telescope Science
 Institute under Contract NAS5-26555, or for ESA by the Hubble European


### PR DESCRIPTION
As part of the provisional package review process, the coordination committee concluded we should add an expectation of python 3.x compatibility to the affiliated package standard.  This PR just adds that to the list of affiliated package standards.

cc @astrofrog @perrygreenfield 