### PR TITLE
Add other pkgs

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -169,6 +169,14 @@
 	</tbody>
 	</table>
 
+	<h3><u>Other astronomy packages</u></h3>
+
+	<p>This section lists some packages that are not affiliated pacakges, but are useful reference (i.e. precursors, overlapping in functionality, etc.) </p>
+
+	<ul>
+	<li> <a href="http://packages.python.org/Astropysics/">astropysics</a>: A library of assorted optical astronomy and astrophysics tools.  A "precursor" of sorts, in the process of getting ported to Astropy.</li>
+	</ul>
+
 	</section>
 	<section id="affiliated-instructions">
 

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -31,16 +31,6 @@
             "description": "Photometry and related image-processing tools."
         },
         {
-            "name": "astropysics",
-            "maintainer": "Erik Tollerud <erik.tollerud@gmail.com>",
-            "provisional": "2015-2-27",
-            "stable": true,
-            "home_url": "http://packages.python.org/Astropysics/",
-            "repo_url": "http://github.com/eteq/astropysics.git",
-            "pypi_name": "Astropysics",
-            "description": "A library of assorted optical astronomy and astrophysics tools (in the process of getting ported to Astropy)."
-        },
-        {
             "name": "ginga",
             "maintainer": "Eric Jeschke <eric@naoj.org>",
             "provisional": "2015-2-27",


### PR DESCRIPTION
This was suggested as part of the provisional package review process.  It removes astropysics (which really duplicates a lot of astropy functionality), but adds an "other packages" section.   You can see what this looks like at http://eteq.github.io/astropy.github.com/affiliated/index.html

Right now the only "other" package is astropysics... What other ones should we add?

cc @astrofrog @perrygreenfield 