### PR TITLE
Add naima to affiliated registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -210,6 +210,17 @@
             "repo_url": "https://github.com/astropy/astroplan",
             "pypi_name": "astroplan",
             "description": "An open source Python package to help astronomers plan observations."
+        },
+        {
+            "name": "naima",
+            "maintainer": "Victor Zabalza <vzabalza@gmail.com>",
+            "provisional": false,
+            "stable": true,
+            "home_url": "https://naima.readthedocs.org/",
+            "repo_url": "https://github.com/zblz/naima",
+            "pypi_name": "naima",
+            "description": "Derivation of non-thermal particle distributions through MCMC spectral fitting."
         }
+
     ]
 }


### PR DESCRIPTION
naima is a pure-Python package that allows to infer the properties of relativistic particle energy distributions from observed nonthermal spectra. It has two major components: a set of nonthermal radiative models (synchrotron, inverse Compton, bremsstrahlung, neutral pion decay), and a set of functions that use emcee to infer the particle distribution properties by fitting observed spectra through an MCMC procedure.

 - Documentation: http://naima.readthedocs.org
 - Code: http://github.com/zblz/naima
 - PyPI: https://pypi.python.org/pypi/naima
