### PR TITLE
Added omnifit to affiliated registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -200,6 +200,15 @@
             "home_url": "http://spectral-cube.rtfd.org",
             "repo_url": "https://github.com/radio-astro-tools/spectral-cube",
             "pypi_name": "spectral-cube"
+        },
+        {
+            "name": "omnifit",
+            "maintainer": "Aleksi Suutarinen <aleksi.suutarinen@iki.fi>",
+            "provisional": false,
+            "stable": true,
+            "home_url": "https://ricemunk.github.io/omnifit/",
+            "repo_url": "https://github.com/RiceMunk/omnifit",
+            "pypi_name": "omnifit"
         }
     ]
 }


### PR DESCRIPTION
I'd like to have Omnifit added to the affiliated package registry, as I described earlier in  [the Google Groups thread](https://groups.google.com/forum/#!topic/astropy-dev/IotGX60E-OA) on the matter.

Omnifit is a package intended for the analysis of astronomical ice spectroscopy, with the special purpose of being able to easily compare data acquired in laboratories with spectra acquired using telescopes. An early version it is featured in my [PhD thesis](https://www.researchgate.net/publication/281458993_Mapping_of_Ice_and_Gas_on_1000_AU_scales), and a paper featuring it is also in final stages of preparation.

The website for Omnifit can be found at https://ricemunk.github.io/omnifit/

Let me know if you have any question or comments on this.