### PR TITLE
Add MaLTPyNT to affiliated registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -210,7 +210,7 @@
             "repo_url": "https://github.com/astropy/astroplan",
             "pypi_name": "astroplan",
             "description": "An open source Python package to help astronomers plan observations."
-        }
+        },
         {
             "name": "MaLTPyNT",
             "maintainer": "Matteo Bachetti <matteo@matteobachetti.it>",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -211,5 +211,14 @@
             "pypi_name": "astroplan",
             "description": "An open source Python package to help astronomers plan observations."
         }
+        {
+            "name": "MaLTPyNT",
+            "maintainer": "Matteo Bachetti <matteo@matteobachetti.it>",
+            "provisional": false,
+            "stable": true,
+            "home_url": "https://bitbucket.org/mbachett/maltpynt",
+            "repo_url": "https://github.com/matteobachetti/MaLTPyNT",
+            "pypi_name": "maltpynt"
+         }
     ]
 }


### PR DESCRIPTION
I would like to propose the MaLTPyNT code as an affiliated package.
This set of libraries and scripts was originally written with the timing properties of the NuSTAR X-ray mission in mind, but it is easily usable with event lists from other X-ray missions or light curves from any instrument.
It makes it possible to calculate light curves starting from event lists, power density spectra, cross spectra and derivatives, and time lags starting from event lists or lightcurves in FITS or text format, from X-ray datasets, and to simulate dead-time affected datasets.

The code is structured according to the Astropy template, and documented following most of the Astropy Guidelines. Astropy functions are used mostly for for FITS handling and time conversions. 
It is distributed through a bitbucket repository (https://bitbucket.org/mbachett/maltpynt) mirrored on GitHub (https://github.com/matteobachetti/MaLTPyNT). The documentation can be found here: http://maltpynt.readthedocs.org/en/latest/. Tests are run with Travis CI (https://travis-ci.org/matteobachetti/MaLTPyNT) and Appveyor (https://ci.appveyor.com/project/matteobachetti/maltpynt).  Python 2.7, 3.3 and 3.4 are supported. Stable releases are deployed to pypi (maltpynt).

Thanks in advance for your consideration.