### PR TITLE
Updating links to point to the webpage or docs page

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -5,7 +5,7 @@
             "maintainer": "Wolfgang Kerzendorf",
             "provisional": false,
             "stable": false,
-            "home_url": "https://github.com/astropy/specutils",
+            "home_url": "http://specutils.readthedocs.org",
             "repo_url": "http://github.com/astropy/specutils.git",
             "pypi_name": "specutils",
             "description": "Spectroscopic analysis utilities."
@@ -15,7 +15,7 @@
             "maintainer": "Adam Ginsburg <adam.g.ginsburg@gmail.com>",
             "provisional": false,
             "stable": true,
-            "home_url": "https://github.com/astropy/astroquery",
+            "home_url": "http://astroquery.readthedocs.org",
             "repo_url": "http://github.com/astropy/astroquery.git",
             "pypi_name": "astroquery",
             "description": "Tools for querying online astronomical data sources."
@@ -25,7 +25,7 @@
             "maintainer": "Larry Bradley and Brigitta Sipocz <lbradley@stsci.edu>",
             "provisional": false,
             "stable": false,
-            "home_url": "https://github.com/astropy/photutils",
+            "home_url": "http://photutils.readthedocs.org/",
             "repo_url": "http://github.com/astropy/photutils.git",
             "pypi_name": "photutils",
             "description": "Photometry and related image-processing tools."
@@ -84,7 +84,7 @@
             "maintainer": "Thomas Robitaille <thomas.robitaille@gmail.com>",
             "provisional": "2016-5-5",
             "stable": true,
-            "home_url": "https://github.com/astrofrog/reproject",
+            "home_url": "http://reproject.readthedocs.org",
             "repo_url": "https://github.com/astrofrog/reproject.git",
             "pypi_name": "reproject"
         },
@@ -93,7 +93,7 @@
             "maintainer": "Ray Plante",
             "provisional": "2016-6-30",
             "stable": false,
-            "home_url": "https://github.com/pyvirtobs/pyvo",
+            "home_url": "http://dev.usvao.org/vao/wiki/Products/PyVO",
             "repo_url": "https://github.com/pyvirtobs/pyvo.git",
             "pypi_name": "pyvo",
             "description": "Access to the Virtual Observatory through Python."
@@ -103,7 +103,7 @@
             "maintainer": "Christoph Deil <Deil.Christoph@gmail.com>",
             "provisional": "2016-6-30",
             "stable": false,
-            "home_url": "https://github.com/gammapy/gammapy",
+            "home_url": "https://gammapy.readthedocs.org/",
             "repo_url": "http://github.com/gammapy/gammapy.git",
             "pypi_name": "gammapy",
             "description": "A high level gamma-ray astronomy data analysis package."
@@ -113,7 +113,7 @@
             "maintainer": "Steven Crawford",
             "provisional": false,
             "stable": false,
-            "home_url": "https://github.com/astropy/ccdproc",
+            "home_url": "http://ccdproc.readthedocs.org",
             "repo_url": "http://github.com/astropy/ccdproc.git",
             "pypi_name": "ccdproc",
             "description": "Package to do basic CCD data reduction."
@@ -132,7 +132,7 @@
             "maintainer": "Thomas Robitaille <thomas.robitaille@gmail.com>",
             "provisional": false,
             "stable": true,
-            "home_url": "https://github.com/astrofrog/wcsaxes",
+            "home_url": "http://wcsaxes.readthedocs.org",
             "repo_url": "https://github.com/astrofrog/wcsaxes.git",
             "pypi_name": "wcsaxes"
         },
@@ -141,7 +141,7 @@
             "maintainer": "Chris Beaumont and Thomas Robitaille <thomas.robitaille@gmail.com>",
             "provisional": "2016-04-27",
             "stable": true,
-            "home_url": "https://www.glue-viz.org",
+            "home_url": "http://www.glue-viz.org",
             "repo_url": "https://github.com/glue-viz/glue.git",
             "pypi_name": "glueviz"
         },
@@ -150,7 +150,7 @@
             "maintainer": "Jae-Joon Lee",
             "provisional": "2016-02-22",
             "stable": true,
-            "home_url": "https://github.com/astropy/pyregion",
+            "home_url": "http://pyregion.readthedocs.org",
             "repo_url": "https://github.com/astropy/pyregion.git",
             "pypi_name": "pyregion"
         },
@@ -240,7 +240,7 @@
             "repo_url": "https://github.com/RiceMunk/omnifit",
             "pypi_name": "omnifit"
         },
-        { 
+        {
             "name": "galpy",
             "maintainer": "Jo Bovy",
             "provisional": "2016-11-1",
@@ -254,8 +254,8 @@
             "maintainer": "Matteo Bachetti <matteo@matteobachetti.it>",
             "provisional": "2017-2-17",
             "stable": true,
-            "home_url": "https://bitbucket.org/mbachett/maltpynt",
-            "repo_url": "https://github.com/matteobachetti/MaLTPyNT",
+            "repo_url": "https://bitbucket.org/mbachett/maltpynt",
+            "home_url": "https://http://maltpynt.readthedocs.org",
             "pypi_name": "maltpynt",
             "description": "Quick-look timing analysis of NuSTAR data."
          }


### PR DESCRIPTION
It makes no sense to list the link of the repos twice, so I've updated the ``home_url``s to point either to the webpage (if there is one), or to the docs page. In the odd cases there isn't any docs page yet, so then repo is left in place.