### PR TITLE
Submit Halotools as a provisional affiliated package

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -258,6 +258,16 @@
             "repo_url": "https://github.com/matteobachetti/MaLTPyNT",
             "pypi_name": "maltpynt",
             "description": "Quick-look timing analysis of NuSTAR data."
+         },
+        {
+            "name": "Halotools",
+            "maintainer": "Andrew Hearin <andrew.hearin@yale.edu>",
+            "provisional": true,
+            "stable": true,
+            "home_url": "https://github.com/astropy/halotools",
+            "repo_url": "https://github.com/astropy/halotools",
+            "pypi_name": "halotools",
+            "description": "Generate Monte Carlo realizations of mock galaxy populations using cosmological simulations."
          }
     ]
 }


### PR DESCRIPTION
This PR modifies `affiliated/registry.json` to apply for affiliated-package status for Halotools. 