### PR TITLE
add mention of gitter in the getting help page

### DIFF
--- a/help.html
+++ b/help.html
@@ -59,10 +59,9 @@
 	<p>The best way to get help is usually by asking questions of the Astropy user and development community. </p>
 
 	<ul>
-		<li>If you want to have a quick question and want immediate feedback, you can join <a href="https://gitter.im/astropy/astropy">Astropy's gitter channel</a>. Gitter is basically a live web chat, but with features that make it better for discussing code. </li>
+		<li>If you want to have a quick question and want immediate feedback, you can join <a href="https://gitter.im/astropy/astropy">Astropy's gitter channel</a>. Gitter is basically a live web chat, but with features that make it better for discussing code. If you prefer using IRC clients for chat, there is <a href="https://irc.gitter.im/">a gitter to IRC bridge</a>.</li>
 		<li>The <a href="http://mail.scipy.org/mailman/listinfo/astropy">astropy users mailing list</a> is a good place to go for more involved questions, as it is more searchable in case other people have the same question.  </li>
 		<li>If you think your question may involve changing Astropy's behavior or adding new features, <a href="http://groups.google.com/group/astropy-dev">the developer list</a> is the place to go. </li>
-		<li> You may also have luck on the #astropy IRC channel on <a href="http://freenode.net/">freenode</a>. You can access this directly in your browser via <a href="http://webchat.freenode.net?channels=astropy" target="_blank">Freenode's #astropy webchat</a>. Gitter (discussed above) is recommended over IRC, though, so you'll likely have better luck there.  </li>
 	</ul>
 
 

--- a/help.html
+++ b/help.html
@@ -59,9 +59,10 @@
 	<p>The best way to get help is usually by asking questions of the Astropy user and development community. </p>
 
 	<ul>
-		<li>The <a href="http://mail.scipy.org/mailman/listinfo/astropy">astropy users mailing list</a> is the first place to go for questions.  </li>
+		<li>If you want to have a quick question and want immediate feedback, you can join <a href="https://gitter.im/astropy/astropy">Astropy's gitter channel</a>. Gitter is basically a live web chat, but with features that make it better for discussing code. </li>
+		<li>The <a href="http://mail.scipy.org/mailman/listinfo/astropy">astropy users mailing list</a> is a good place to go for more involved questions, as it is more searchable in case other people have the same question.  </li>
 		<li>If you think your question may involve changing Astropy's behavior or adding new features, <a href="http://groups.google.com/group/astropy-dev">the developer list</a> is the place to go. </li>
-		<li> If you are in a hurry, you may also have luck on the #astropy IRC channel on <a href="http://freenode.net/">freenode</a>. You can access this directly in your browser via <a href="http://webchat.freenode.net?channels=astropy" target="_blank">Freenode's #astropy webchat</a>.  </li>
+		<li> You may also have luck on the #astropy IRC channel on <a href="http://freenode.net/">freenode</a>. You can access this directly in your browser via <a href="http://webchat.freenode.net?channels=astropy" target="_blank">Freenode's #astropy webchat</a>. Gitter (discussed above) is recommended over IRC, though, so you'll likely have better luck there.  </li>
 	</ul>
 
 


### PR DESCRIPTION
This updates the "getting help" page to point people to the astropy gitter channel. Prompted by @cdeil's suggestion on astropy-dev.

Note that, at least for now, I am *not* removing the mention of the IRC channel as it still has occasional people there.  But it's at the bottom of the list so we can probably phase it out if gitter does indeed catch on this time. 

cc @cdeil @astrofrog