### PR TITLE
Add Miguel de Vol-Borro in Arch linux role

### DIFF
--- a/roles.txt
+++ b/roles.txt
@@ -29,7 +29,7 @@ Core package release coordinator | | Erik Tollerud::Would prefer deputy role | T
 Distribution coordinator    | Conda    | Matt Craig | UNFILLED
                             | Debian   | Ole Streicher | UNFILLED
                             | Fedora   | Sergio Pascual | UNFILLED
-                            | ArchLinux| Miguel de Val-Borro | UNFILLED
+                            | ArchLinux| Médéric Boquien | Miguel de Val-Borro, Stuart Mumford
                             | MacPorts | Tom Robitaille::Would prefer deputy role | UNFILLED
 
 Package-template maintainer | | Tom Robitaille::Would prefer deputy role | Brigitta Sipocz, Larry Bradley, Adrian Price-Whelan

--- a/roles.txt
+++ b/roles.txt
@@ -29,7 +29,7 @@ Core package release coordinator | | Erik Tollerud::Would prefer deputy role | T
 Distribution coordinator    | Conda    | Matt Craig | UNFILLED
                             | Debian   | Ole Streicher | UNFILLED
                             | Fedora   | Sergio Pascual | UNFILLED
-                            | ArchLinux| UNFILLED | UNFILLED
+                            | ArchLinux| Miguel de Val-Borro | UNFILLED
                             | MacPorts | Tom Robitaille::Would prefer deputy role | UNFILLED
 
 Package-template maintainer | | Tom Robitaille::Would prefer deputy role | Brigitta Sipocz, Larry Bradley, Adrian Price-Whelan

--- a/team.html
+++ b/team.html
@@ -183,7 +183,7 @@
                  <tr>
                   <td></td>
                   <td>ArchLinux</td>
-                  <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
+                  <td>Miguel de Val-Borro</td>
                   <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
                  </tr>
                  <tr>

--- a/team.html
+++ b/team.html
@@ -183,8 +183,8 @@
                  <tr>
                   <td></td>
                   <td>ArchLinux</td>
-                  <td>Miguel de Val-Borro</td>
-                  <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
+                  <td>Médéric Boquien</td>
+                  <td>Miguel de Val-Borro,  Stuart Mumford</td>
                  </tr>
                  <tr>
                   <td></td>


### PR DESCRIPTION
> I will be glad to have a lead or deputy role for Arch Linux packaging.
> 
> Best,
> Miguel
