### PR TITLE
Add Matteo Bachetti in deputy io.misc role

### DIFF
--- a/roles.txt
+++ b/roles.txt
@@ -41,7 +41,7 @@ Sub-package maintainer | astropy.analytic_functions | Pey Lian Lim | Larry Bradl
                        | astropy.cosmology | Alex Conley | Neil Crighton
                        | astropy.io.ascii | Tom Aldcroft | Moritz Guenther
                        | astropy.io.fits | UNFILLED  | Michael Seifert, Pey-Lian Lim
-                       | astropy.io.misc | Tom Robitaille::Would prefer deputy role | UNFILLED
+                       | astropy.io.misc | Tom Robitaille::Would prefer deputy role | Matteo Bachetti
                        | astropy.io.votable | UNFILLED | Pey-Lian Lim
                        | astropy.modeling | Nadia Dencheva | Pey-Lian Lim
                        | astropy.nddata | Matt Craig | Steve Crawford, Michael Seifert

--- a/team.html
+++ b/team.html
@@ -244,7 +244,7 @@
                   <td></td>
                   <td>astropy.io.misc</td>
                   <td><span style="color: blue;">Tom Robitaille<sup>1</sup></span></td>
-                  <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
+                  <td>Matteo Bachetti</td>
                  </tr>
                  <tr>
                   <td></td>


### PR DESCRIPTION
> I would like to volunteer for the unfilled role of deputy in astropy.io.misc.
> 
> I do a lot of I/O with Astropy Tables, in particular in HDF5 format, so I know well enough how it works (so that I can participate actively in the discussion when people submit PRs) and also some points where I would like to propose changes. 
> 
> Let me know if I can help with this, or feel free to suggest parts of the project where more help is needed. I use a lot the following subpackages: table, modeling, io.*, and sometimes coordinates, units, time, wcs.
> 
> I'm the principal maintainer of MaLTPyNT, a provisionally-accepted astropy-affiliated package (now being merged into github.com/stingraysoftware/stingray, for which we will ask for affiliation eventually), and the Sardinia Radio Telescope Single Dish Tools (http://matteobachetti.github.io/srt-single-dish-tools/, also using the Astropy template and a lot of Astropy machinery in the core).
> 
> Cheers,
> Matteo
