### PR TITLE
Add Sébastien Fabbro as Gentoo packager

### DIFF
--- a/roles.txt
+++ b/roles.txt
@@ -29,6 +29,7 @@ Core package release coordinator | | Erik Tollerud::Would prefer deputy role | T
 Distribution coordinator    | Conda    | Matt Craig | UNFILLED
                             | Debian   | Ole Streicher | UNFILLED
                             | Fedora   | Sergio Pascual | UNFILLED
+                            | Gentoo   | Sébastien Fabbro | UNFILLED
                             | ArchLinux| UNFILLED | UNFILLED
                             | MacPorts | Tom Robitaille::Would prefer deputy role | UNFILLED
 

--- a/team.html
+++ b/team.html
@@ -182,6 +182,12 @@
                  </tr>
                  <tr>
                   <td></td>
+                  <td>Gentoo</td>
+                  <td>Sébastien Fabbro</td>
+                  <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
+                 </tr>
+                 <tr>
+                  <td></td>
                   <td>ArchLinux</td>
                   <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
                   <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>


### PR DESCRIPTION
Sébastien Fabbro has volunteered and committed to this role for at least a year.
