### PR TITLE
Add Grant Tremblay to Astropy Website deputy role

### DIFF
--- a/roles.txt
+++ b/roles.txt
@@ -11,7 +11,7 @@ Coordination committee member | | Tom Aldcroft    |
                               | | Tom Robitaille  |
                               | | Erik Tollerud   |
 
-Astropy.org web page maintainer | | Erik Tollerud::Would prefer deputy role | UNFILLED
+Astropy.org web page maintainer | | Erik Tollerud::Would prefer deputy role | Grant Tremblay
 
 Astropy-helpers maintainer | | UNFILLED | Erik Tollerud, Brigitta Sipocz, Erik Bray
 

--- a/team.html
+++ b/team.html
@@ -112,7 +112,7 @@
                   <td><a href="#Astropyorg_web_page_maintainer">Astropy.org web page maintainer</a></td>
                   <td></td>
                   <td><span style="color: blue;">Erik Tollerud<sup>1</sup></span></td>
-                  <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
+                  <td>Grant Tremblay</td>
                  </tr>
                  <tr>
                   <td><a href="#Astropyhelpers_maintainer">Astropy-helpers maintainer</a></td>


### PR DESCRIPTION
Per request from @eteq, I'm adding myself to the deputy slot for the Astropy web site role. Happy to be helping out! 
