### PR TITLE
Update lead and deputy for astropy.constants

### DIFF
--- a/roles.txt
+++ b/roles.txt
@@ -36,7 +36,7 @@ Distribution coordinator    | Conda    | Matt Craig | UNFILLED
 Package-template maintainer | | Tom Robitaille::Would prefer deputy role | Brigitta Sipocz, Larry Bradley, Adrian Price-Whelan
 
 Sub-package maintainer | astropy.analytic_functions | Pey Lian Lim | Larry Bradley
-                       | astropy.constants | UNFILLED | UNFILLED
+                       | astropy.constants | Tom Aldcroft::Responsible primarily for process | David Shupe, Ken Young
                        | astropy.convolution | Adam Ginsburg | Axel Donath, Larry Bradley
                        | astropy.coordinates | Erik Tollerud | Stuart Littlefair, Adrian Price-Whelan
                        | astropy.cosmology | Alex Conley | Neil Crighton

--- a/team.html
+++ b/team.html
@@ -213,8 +213,8 @@
                  <tr>
                   <td></td>
                   <td>astropy.constants</td>
-                  <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
-                  <td><a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a></td>
+                  <td><span style="color: blue;">Tom Aldcroft<sup>2</sup></span></td>
+                  <td>David Shupe,  Ken Young</td>
                  </tr>
                  <tr>
                   <td></td>
@@ -332,6 +332,12 @@
                  </tr>
                  <tr>
                   <td><span style="color: blue;"><sup>1</sup>Would prefer deputy role</span></td>
+                  <td></td>
+                  <td></td>
+                  <td></td>
+                 </tr>
+                 <tr>
+                  <td><span style="color: blue;"><sup>2</sup>Responsible primarily for process</span></td>
                   <td></td>
                   <td></td>
                   <td></td>


### PR DESCRIPTION
This adds Tom Aldcroft as "process-only" lead and David Shupe as deputy with primary responsibility for technical review and development.
