### PR TITLE
Add @bsipocz as releaser

### DIFF
--- a/roles.txt
+++ b/roles.txt
@@ -24,7 +24,7 @@ Community engagement coordinator | Overall  | Kelle Cruz | UNFILLED
                                  | Facebook | Kelle Cruz | Tom Robitaille, Erik Tollerud
                                  | Conferences | Adrian Price-Whelan | Erik Tollerud, Tom Robitaille, Kelle Cruz
 
-Core package release coordinator | | Erik Tollerud::Would prefer deputy role | Tom Robitaille::Can take lead while training new <br> deputy / future lead, Brigitta Sipocz
+Core package release coordinator | | Erik Tollerud::Would prefer deputy role | Tom Robitaille, Brigitta Sipocz
 
 Distribution coordinator    | Conda    | Matt Craig | UNFILLED
                             | Debian   | Ole Streicher | UNFILLED

--- a/roles.txt
+++ b/roles.txt
@@ -24,7 +24,7 @@ Community engagement coordinator | Overall  | Kelle Cruz | UNFILLED
                                  | Facebook | Kelle Cruz | Tom Robitaille, Erik Tollerud
                                  | Conferences | Adrian Price-Whelan | Erik Tollerud, Tom Robitaille, Kelle Cruz
 
-Core package release coordinator | | Erik Tollerud::Would prefer deputy role | Tom Robitaille::Can take lead while training new <br> deputy / future lead
+Core package release coordinator | | Erik Tollerud::Would prefer deputy role | Tom Robitaille::Can take lead while training new <br> deputy / future lead, Brigitta Sipocz
 
 Distribution coordinator    | Conda    | Matt Craig | UNFILLED
                             | Debian   | Ole Streicher | UNFILLED

--- a/team.html
+++ b/team.html
@@ -160,7 +160,7 @@
                   <td><a href="#Core_package_release_coordinator">Core package release coordinator</a></td>
                   <td></td>
                   <td><span style="color: blue;">Erik Tollerud<sup>1</sup></span></td>
-                  <td><span style="color: blue;">Tom Robitaille<sup>2</sup></span>,  Brigitta Sipocz</td>
+                  <td>Tom Robitaille,  Brigitta Sipocz</td>
                  </tr>
                  <tr>
                   <td><a href="#Distribution_coordinator">Distribution coordinator</a></td>
@@ -332,12 +332,6 @@
                  </tr>
                  <tr>
                   <td><span style="color: blue;"><sup>1</sup>Would prefer deputy role</span></td>
-                  <td></td>
-                  <td></td>
-                  <td></td>
-                 </tr>
-                 <tr>
-                  <td><span style="color: blue;"><sup>2</sup>Can take lead while training new <br> deputy / future lead</span></td>
                   <td></td>
                   <td></td>
                   <td></td>

--- a/team.html
+++ b/team.html
@@ -160,7 +160,7 @@
                   <td><a href="#Core_package_release_coordinator">Core package release coordinator</a></td>
                   <td></td>
                   <td><span style="color: blue;">Erik Tollerud<sup>1</sup></span></td>
-                  <td><span style="color: blue;">Tom Robitaille<sup>2</sup></span></td>
+                  <td><span style="color: blue;">Tom Robitaille<sup>2</sup></span>,  Brigitta Sipocz</td>
                  </tr>
                  <tr>
                   <td><a href="#Distribution_coordinator">Distribution coordinator</a></td>


### PR DESCRIPTION
Adds @bsipocz to the roles as a deputy release manager.

Also removes the footnote for @astrofrog (is that ok?  I can back out the commit if not, @astrofrog)