### PR TITLE
update reproject and glue to full affiliated status

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -82,7 +82,7 @@
         {
             "name": "reproject",
             "maintainer": "Thomas Robitaille <thomas.robitaille@gmail.com>",
-            "provisional": "2016-5-5",
+            "provisional": false,
             "stable": true,
             "home_url": "http://reproject.readthedocs.io",
             "repo_url": "https://github.com/astrofrog/reproject.git",
@@ -139,7 +139,7 @@
         {
             "name": "Glue",
             "maintainer": "Chris Beaumont and Thomas Robitaille <thomas.robitaille@gmail.com>",
-            "provisional": "2016-04-27",
+            "provisional": false,
             "stable": true,
             "home_url": "http://www.glueviz.org",
             "repo_url": "https://github.com/glue-viz/glue.git",


### PR DESCRIPTION
This PR updates the "glue" and "reproject" provisional affiliated packages to full affiliated package status.

The author of these packages (@astrofrog) requested a re-review, and the coordination committee (sans @astrofrog himself) agreed that both packages are sufficiently mature and meeting the affiliated package standards to be upgraded to full.

One item of discussion was the nature of `glue` as a non-astro-specific library.  There was some question whether that means it belongs as an affiliated package.  However, given its use in astronomy, the substantial (and continuing) effort @astrofrog has put into making it compatible with `astropy`, and the simple fact that the authors made the request, we concluded it is just fine.
