### PR TITLE
Replace PyVO webpage link

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -93,7 +93,7 @@
             "maintainer": "Ray Plante",
             "provisional": "2016-6-30",
             "stable": false,
-            "home_url": "http://dev.usvao.org/vao/wiki/Products/PyVO",
+            "home_url": "http://pyvo.readthedocs.io/",
             "repo_url": "https://github.com/pyvirtobs/pyvo.git",
             "pypi_name": "pyvo",
             "description": "Access to the Virtual Observatory through Python."


### PR DESCRIPTION
The old link is dead, and this seems to be the new one. Pinging the maintainer in case I'm wrong @RayPlante