### PR TITLE
Add poliastro to affiliated packages

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -286,6 +286,16 @@
             "home_url": "http://jesford.github.io/cluster-lensing",
             "pypi_name": "cluster-lensing",
             "description": "Galaxy cluster properties and NFW profiles (with miscentering option)."
-         }
+        },
+        {
+            "name": "poliastro",
+            "maintainer": "Juan Luis Cano Rodríguez",
+            "provisional": "2017-3-22",
+            "stable": false,
+            "repo_url": "https://github.com/poliastro/poliastro",
+            "home_url": "http://poliastro.github.io/",
+            "pypi_name": "poliastro",
+            "description": "Astrodynamics and Orbital Mechanics computations"
+        }
     ]
 }


### PR DESCRIPTION
By suggestion of @mhvk I'm proposing poliastro as an Astropy affiliated package. poliastro is a open source collection of Python subroutines useful in Astrodynamics and Orbital Mechanics, focusing on interplanetary applications. Some features include:

* Analytical and numerical orbit propagation
* Conversion between position and velocity vectors and classical orbital elements
* Hohmann and bielliptic maneuvers computation
* Trajectory plotting
* Initial orbit determination (Lambert problem)

It uses Astropy extensively for time conversion, physical unit handling, and now ephemerides computation.

Documentation: http://poliastro.readthedocs.io/en/latest/
Source code: https://github.com/poliastro/poliastro
Mailing list: https://groups.io/g/poliastro-dev

Mail to astropy-dev to follow.