### PR TITLE
Propose MARXS as affiliated package

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -290,7 +290,7 @@
          {
             "name": "marxs",
             "maintainer": "Hans Moritz Günther (hamogu)",
-            "provisional": "2017-4-XX",
+            "provisional": false,
             "stable": true,
             "repo_url": "https://github.com/Chandra-MARX/marxs",
             "home_url": "https://marxs.readthedocs.io/",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -287,5 +287,15 @@
             "pypi_name": "cluster-lensing",
             "description": "Galaxy cluster properties and NFW profiles (with miscentering option)."
          }
+         {
+            "name": "marxs",
+            "maintainer": "Hans Moritz Günther (hamogu)",
+            "provisional": "2017-4-XX",
+            "stable": true,
+            "repo_url": "https://github.com/Chandra-MARX/marxs",
+            "home_url": "https://marxs.readthedocs.io/",
+            "pypi_name": "marxs",
+            "description": "Multi-Architecture-Raytrace-Xraymission-Simulator"
+         }
     ]
 }

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -286,7 +286,7 @@
             "home_url": "http://jesford.github.io/cluster-lensing",
             "pypi_name": "cluster-lensing",
             "description": "Galaxy cluster properties and NFW profiles (with miscentering option)."
-         }
+         },
          {
             "name": "marxs",
             "maintainer": "Hans Moritz Günther (hamogu)",


### PR DESCRIPTION
MARXS (Multi-Architecture-Raytrace-Xraymission-Simulator) is a toolsuite to simulate X-ray observatories. It is primarily aimed at astronomical X-ray satellites and sounding rocket payloads, but can be used to ray-trace experiments in the laboratory as well. MARXS performs polarization Monte-Carlo ray-trace simulations from a source (astronomical or lab) through a collection of optical elements such as mirrors, baffles, and gratings to a detector.

MARXS modular structure is designed to serve two main use cases:

-   Build-your-own instrument: Instrument designers can construct any X-ray experiement from a set of building blocks such as mirrors, diffraction gratings and CCD detectors.
-    Simulate science observations: Given an instrument configuration, simulate the detector output for any set of X-ray sources in the lab or on the sky.