### PR TITLE
make whats new centered and include current version

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -427,7 +427,20 @@ section.whatsnew{
 	border-right-style:none;
 	border-left-style:none;
 	border-padding=1px;
+	padding-top: 15px;
+	padding-bottom: 15px;
+}
 
+section.whatsnew .version{
+	color:grey;
+	font-size: 12px;
+	margin-top:6px;
+	margin-bottom:0px;
+}
+
+.whatsnew{
+	font-size: 24px;
+	text-align: center;
 }
 
 /*Installation Instructions*/
@@ -676,8 +689,8 @@ color: white;
     position: absolute;
     right: -13px;
     top: 9px;
-    width: 0; 
-    height: 0; 
+    width: 0;
+    height: 0;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
     border-top: 5px solid white;

--- a/index.html
+++ b/index.html
@@ -84,7 +84,8 @@
   </section>
 
 <section class="whatsnew">
-		<h1>What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/1.3.html">Astropy 1.3?</a></h1>
+	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/1.3.html">Astropy 1.3?</a>
+	<p class="version">Current Version: 1.3.3</p>
 
 </section>
 	<section class="install">


### PR DESCRIPTION
This is one of the things I said I'd like to modify in #159 (https://github.com/astropy/astropy.github.com/pull/159#issuecomment-307214063).  It updates the front page to include the current version in the "what's new" section, looking something like this:

![image](https://user-images.githubusercontent.com/346587/26955513-26dab246-4c85-11e7-8d6d-878f16ae0887.png)

I think this also actually addresses my "wall of text" concern in #159 now that I see it.  What do you think about this, @abostroem and @kelle?
