### PR TITLE
Add documentation dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,24 @@
 				</li>
 				<li><a href="help.html">Get Help</a></li>
 				<li><a href="contribute.html">Contribute</a></li>
-				<li><a href="http://docs.astropy.org" target="_blank">Documentation</a></li>
+				<li>
+					<div class="dropdown">
+						<a href="http://docs.astropy.org">Documentation</a>
+						<div class="dropdown-content">
+							<ul>
+								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
+								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.2.2/index.html" target="_blank">v1.2.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.1.2/index.html" target="_blank">v1.1.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.0.13/index.html" target="_blank">v1.0.13</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.4.6/index.html" target="_blank">v0.4.6</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.3.2/index.html" target="_blank">v0.3.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.2.5/index.html" target="_blank">v0.2.5</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.1/index.html" target="_blank">v0.1</a></li>
+							</ul>
+						</div>
+					</div>
+				</li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
 				<li><a href="team.html">Team</a></li>
 			</ul>

--- a/index.html
+++ b/index.html
@@ -29,24 +29,24 @@
 		</div>
 		<a href="index.html"><img src="images/astropy_word.svg" height="32" onerror="this.src='images/astropy_word_32.png; this.onerror=null;"/></a>
 		<div id="navigation">
-		<ul>
-		    <li>
-                <div class="dropdown">
-                  <a>About</a>
-                  <div class="dropdown-content">
-                    <ul>
-                    <li><a href="about.html">About Astropy</a></li>
-                    <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="acknowledging.html">Acknowledging</a></li>                    
-                    </ul>
-                  </div>
-                </div>
-			    </li>
+			<ul>
+				<li>
+					<div class="dropdown">
+						<a>About</a>
+						<div class="dropdown-content">
+							<ul>
+								<li><a href="about.html">About Astropy</a></li>
+								<li><a href="code_of_conduct.html">Code of Conduct</a></li>
+								<li><a href="acknowledging.html">Acknowledging</a></li>
+							</ul>
+						</div>
+					</div>
+				</li>
 				<li><a href="help.html">Get Help</a></li>
 				<li><a href="contribute.html">Contribute</a></li>
-				<li><a href="http://docs.astropy.org" target="_blank">Documentation</a></li> 
+				<li><a href="http://docs.astropy.org" target="_blank">Documentation</a></li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
-                <li><a href="team.html">Team</a></li>
+				<li><a href="team.html">Team</a></li>
 			</ul>
 		</div>
 		<div class="search pull-right">
@@ -62,10 +62,10 @@
 		<img src="images/astropy_banner.svg" width="524" onerror="this.src='images/astropy_banner_96.png'; this.onerror=null;" alt="Astropy: a community Python library for Astronomy" />
 		<p>The Astropy Project is a community effort to develop a single core
 		package for Astronomy in Python and foster interoperability between Python
-		astronomy packages.</p>		
+		astronomy packages.</p>
 		<p class="acknowledge">Please remember to <a href="acknowledging.html">acknowledge</a> the use of Astropy!</p>
   </section>
-  
+
 <section class="whatsnew">
 		<h1>What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/1.3.html">Astropy 1.3?</a></h1>
 


### PR DESCRIPTION
This is the other thing I said I'd like to modify in #159 (https://github.com/astropy/astropy.github.com/pull/159#issuecomment-307214063), in addition to #163. It updates the front page to have "Documentation" use the fancy dropdown thing @abostroem made for the "About".  Looks like this:
![image](https://user-images.githubusercontent.com/346587/26955585-9f1856dc-4c85-11e7-8ceb-1ecf170f49ca.png)

@abostroem and @kelle ?