### PR TITLE
Make sidebar be the gradient instead of pure orange

### DIFF
--- a/css/jquery.sidr.light.css
+++ b/css/jquery.sidr.light.css
@@ -15,6 +15,19 @@
 	-o-transition: none;
 	-ms-transition: none
 	transition: none;
+	background-image: -webkit-gradient(
+	linear,
+	left top,
+	left bottom,
+	color-stop(0, #FC9468),
+	color-stop(0.89, #FF5100)
+	);
+	background-image: -o-linear-gradient(bottom, #FC9468 0%, #FF5100 89%);
+	background-image: -moz-linear-gradient(bottom, #FC9468 0%, #FF5100 89%);
+	background-image: -webkit-linear-gradient(bottom, #FC9468 0%, #FF5100 89%);
+	background-image: -ms-linear-gradient(bottom, #FC9468 0%, #FF5100 89%);
+	background-image: linear-gradient(to bottom, #FC9468 0%, #FF5100 89%);
+				border-radius: 3px;
 }
 
 .sidr ul li:hover>a, .sidr ul li:hover>span, .sidr ul li.active>a, .sidr ul li.active>span, .sidr ul li.sidr-class-active>a, .sidr ul li.sidr-class-active>span{
@@ -28,4 +41,6 @@
 	-o-transition: none;
 	-ms-transition: none
 	transition: none;
+
+	background-image: none;
 }


### PR DESCRIPTION
While working on #162 and #163 I noticed that when the sidebar appears with the menu (more importantly, it's what you see on a phone), you get this color:
![image](https://user-images.githubusercontent.com/346587/26955620-eb58e4e4-4c85-11e7-850a-44461172b36a.png)

That solid orange was very glaring and painful (at least on my monitor), so this PR changes it to match the gradient that the "buttons" on the rest of the page look like:
![image](https://user-images.githubusercontent.com/346587/26955658-2b247ac0-4c86-11e7-868d-bebba04c1e21.png)

I think this is much more pleasant to look at.  This is quite subjective though, so it would be good to hear if others agree!