### PR TITLE
A little cleanup of affiliated package json

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -110,7 +110,7 @@
         },
         {
             "name": "ccdproc",
-            "maintainer": "Steven Crawford and Matt Craig <ccdproc@gmail.com>",
+            "maintainer": "Steven Crawford, Matt Craig and Michael Seifert <ccdproc@gmail.com>",
             "provisional": false,
             "stable": true,
             "home_url": "http://ccdproc.readthedocs.io",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -128,15 +128,6 @@
             "pypi_name": "sncosmo"
         },
         {
-            "name": "WCSAxes",
-            "maintainer": "Thomas Robitaille <thomas.robitaille@gmail.com>",
-            "provisional": false,
-            "stable": true,
-            "home_url": "http://wcsaxes.readthedocs.io",
-            "repo_url": "https://github.com/astrofrog/wcsaxes.git",
-            "pypi_name": "wcsaxes"
-        },
-        {
             "name": "Glue",
             "maintainer": "Chris Beaumont and Thomas Robitaille <thomas.robitaille@gmail.com>",
             "provisional": false,


### PR DESCRIPTION
This should be looked at by @astrofrog because of the second commit, which removes WCSAxes. 

That may not be the way to handle packages that have migrated into core, but I was looking at the json anyway and figured I'd raise the issue. Happy to revert if desired....