### PR TITLE
added release announcement for 2.0

### DIFF
--- a/announcements/release-2.0.html
+++ b/announcements/release-2.0.html
@@ -164,7 +164,7 @@ pip install astropy --upgrade
 		<p>where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
 		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).</p>
 		<p>
-		Please feel free to forward this announcement to anyone you think might be interested in this release.
+		Special thanks to the coordinator for this release: Brigitta Sipocz.
 		</p>
 		<p>
 		We hope that you enjoy using Astropy as much as we enjoyed developing it!

--- a/announcements/release-2.0.html
+++ b/announcements/release-2.0.html
@@ -102,10 +102,12 @@
 		<li>A new CCDData class that is directly useful for typical astronomical images and implements the NDData interface.</li>
 		<li>Coordinate frame objects can now carry proper motions and radial velocities, and will carry them through and transform them between frames. (This functionality is experimental and feedback is greatly desired.)</li>
 		<li>Many of the typical mixin columns for astropy tables can now be saved into ECSV files and fully round-tripped.</li>
-		<li>astropy.convolution is now more consistent between the fft and direct versions of the algorithm and work better and more consistently with typical use cases.</li>
-		<li>A variety of dditions to the astropy.stats subpackage</li>
-		<li>The Astropy 2.x series will be the last versions of Astropy that will support Python 2.x.  Future versions of Astropy will only support Python 3.x.</li>
+		<li>The fft and direct versions of the convolution algorithm in astropy.convolution are now more consistent and work better with typical use cases.</li>
+		<li>A variety of additions to the astropy.stats subpackage</li>
 		</ul>
+		</p>
+		<p>
+		Note that the Astropy 2.x series will be the last versions of Astropy that will support Python 2.x.  Future versions of Astropy will only support Python 3.x.
 		</p>
 		<p>
 		In addition, hundreds of smaller improvements and fixes have been made. An
@@ -148,7 +150,7 @@ pip install astropy --upgrade
 		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://www.astropy.org/team.html">http://www.astropy.org/team.html</a>
 		</p>
 		<p>
-		Astropy v2.0 now repaces v1.0 as the long term support release, and will be supported for the next 2 years.  The next major release of Astropy (scheduled for January 2018), will also be an LTS, but it will only support Python 3.x. So if you need to use Astropy in a very stable  environment in python 2.7, this is the one for you.
+		Astropy v2.0 now repaces v1.0 as the long term support release, and will be supported until the end of 2019.  The next major release of Astropy (scheduled for January 2018) will only support Python 3.x. So if you need to use Astropy in a very stable environment in Python 2.7, you should continue to use the 2.0.x series after 3.0.x is released.
 		</p>
 		<p>
 		If you use Astropy directly for your work, or as a dependency to another

--- a/announcements/release-2.0.html
+++ b/announcements/release-2.0.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="description" content="Astropy. A Community Python Library for Astronomy." />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="shortcut icon" href="favicon.ico" />
+
+<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css' />
+<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+<link rel="stylesheet" type="text/css" href="../css/style.css" />
+<link rel="stylesheet" type="text/css" href="../css/jquery.sidr.light.css" />
+
+
+<title>Astropy | v2.0 Released!</title>
+
+<!-- Google analytics -->
+<script src="../js/analytics.js"></script>
+</head>
+
+<body>
+
+<div id="wrapper">
+	<nav>
+		<div id="mobile-header">
+			<!-- Menu Icon -->
+		    <a id="responsive-menu-button" href="#sidr-main"><div><svg senable-background="new 0 0 24 24" height="24px" id="Layer_1" version="1.1" viewBox="0 0 24 24" width="24px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g><g><path d="M23.244,17.009H0.75c-0.413,0-0.75,0.36-0.75,0.801v3.421C0,21.654,0.337,22,0.75,22h22.494c0.414,0,0.75-0.346,0.75-0.77    V17.81C23.994,17.369,23.658,17.009,23.244,17.009z M23.244,9.009H0.75C0.337,9.009,0,9.369,0,9.81v3.421    c0,0.424,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.345,0.75-0.769V9.81C23.994,9.369,23.658,9.009,23.244,9.009z     M23.244,1.009H0.75C0.337,1.009,0,1.369,0,1.81V5.23c0,0.423,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.346,0.75-0.769V1.81    C23.994,1.369,23.658,1.009,23.244,1.009z"/></g></g></svg></div></a>
+		    <!-- -->
+		</div>
+		<a href="../index.html"><img src="../images/astropy_word.svg" height="32" onerror="this.src='../images/astropy_word_32.png; this.onerror=null;"/></a>
+		<div id="navigation">
+			<ul>
+				<li>
+					<div class="dropdown">
+						<a>About</a>
+						<div class="dropdown-content">
+							<ul>
+								<li><a href="../about.html">About Astropy</a></li>
+								<li><a href="../code_of_conduct.html">Code of Conduct</a></li>
+								<li><a href="../acknowledging.html">Acknowledging</a></li>
+							</ul>
+						</div>
+					</div>
+				</li>
+				<li><a href="../help.html">Get Help</a></li>
+				<li><a href="../contribute.html">Contribute</a></li>
+				<li>
+					<div class="dropdown">
+						<a href="http://docs.astropy.org">Documentation</a>
+						<div class="dropdown-content">
+							<ul>
+								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
+								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.2.2/index.html" target="_blank">v1.2.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.1.2/index.html" target="_blank">v1.1.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.0.13/index.html" target="_blank">v1.0.13</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.4.6/index.html" target="_blank">v0.4.6</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.3.2/index.html" target="_blank">v0.3.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.2.5/index.html" target="_blank">v0.2.5</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.1/index.html" target="_blank">v0.1</a></li>
+							</ul>
+						</div>
+					</div>
+				</li>
+				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
+				<li><a href="team.html">Team</a></li>
+			</ul>
+		</div>
+		<div class="search pull-right">
+			<form action="http://docs.astropy.org/en/stable/search.html" method="get">
+			  <input type="text" name="q" placeholder="Search Documentation" />
+			  <input type="hidden" name="check_keywords" value="yes" />
+			  <input type="hidden" name="area" value="default" />
+			</form>
+		</div>
+	</nav>
+
+
+	<section>
+
+		<h1>Astropy v2.0 Released!</h1>
+
+		<p>
+		Dear colleagues,
+		</p>
+		<p>
+		We are very happy to announce the v2.0 release of the Astropy package,
+		a core Python package for Astronomy:
+		</p>
+		<p align='center'>
+		    <img src="astropy_logo_notext.png" style="width:80px;height:80px;"><br>
+		    <a href="http://www.astropy.org">http://www.astropy.org</a>
+		</p>
+		<p>
+		Astropy is a community-driven Python package intended to contain much of the
+		core functionality and common tools needed for astronomy and astrophysics.
+		</p>
+		<p>
+		New and improved major functionality in this release includes:
+		<ul>
+		<li>Most models now support parameters having units (i.e., being Quantity objects).</li>
+		<li>A new CCDData class that is directly useful for typical astronomical images and implements the NDData interface.</li>
+		<li>Coordinate frame objects can now carry proper motions and radial velocities, and will carry them through and transform them between frames. (This functionality is experimental and feedback is greatly desired.)</li>
+		<li>Many of the typical mixin columns for astropy tables can now be saved into ECSV files and fully round-tripped.</li>
+		<li>astropy.convolution is now more consistent between the fft and direct versions of the algorithm and work better and more consistently with typical use cases.</li>
+		<li>A variety of dditions to the astropy.stats subpackage</li>
+		<li>The Astropy 2.x series will be the last versions of Astropy that will support Python 2.x.  Future versions of Astropy will only support Python 3.x.</li>
+		</ul>
+		</p>
+		<p>
+		In addition, hundreds of smaller improvements and fixes have been made. An
+		overview of the changes is provided at:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://docs.astropy.org/en/stable/whatsnew/2.0.html">http://docs.astropy.org/en/stable/whatsnew/2.0.html</a>
+		</p>
+		<p>
+		Instructions for installing Astropy are provided on our <a
+		href="http://www.astropy.org">website</a>, and extensive documentation can be
+		found at:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://docs.astropy.org">http://docs.astropy.org</a>
+		</p>
+		<p>
+		If you make use of the <a href="https://www.continuum.io/downloads">Anaconda
+		Python Distribution</a>, you can update to Astropy v2.0 with:
+		</p>
+<pre>
+conda update astropy
+</pre>
+		<p>
+		  Whereas if you usually use pip, you can do:
+		</p>
+<pre>
+pip install astropy --upgrade
+</pre>
+		<p>
+		Please report any issues, or request new features via our GitHub repository:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/astropy/astropy/issues">https://github.com/astropy/astropy/issues</a>
+		</p>
+		<p>
+		Over 232 developers have contributed code to Astropy so far, and you can find out more about the team behind Astropy here:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://www.astropy.org/team.html">http://www.astropy.org/team.html</a>
+		</p>
+		<p>
+		Astropy v2.0 now repaces v1.0 as the long term support release, and will be supported for the next 2 years.  The next major release of Astropy (scheduled for January 2018), will also be an LTS, but it will only support Python 3.x. So if you need to use Astropy in a very stable  environment in python 2.7, this is the one for you.
+		</p>
+		<p>
+		If you use Astropy directly for your work, or as a dependency to another
+		package, please remember to include the following acknowledgment at the end of
+		papers:
+		</p>
+		<p class="citation"><cite>This research made use of Astropy, a
+		community-developed core Python package for Astronomy (Astropy Collaboration,
+		2013).</cite></p>
+
+		<p>where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
+		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).</p>
+		<p>
+		Please feel free to forward this announcement to anyone you think might be interested in this release.
+		</p>
+		<p>
+		We hope that you enjoy using Astropy as much as we enjoyed developing it!
+		</p>
+		<p>
+		Erik Tollerud, Tom Robitaille, Kelle Cruz, and Tom Aldcroft<br>
+		on behalf of The Astropy Collaboration
+		</p>
+	</section>
+
+
+
+	<footer>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+		<script src="js/jquery.sidr.min.js"></script>
+		<script src="js/functions.js"></script>
+	</footer>
+
+</div>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@
   </section>
 
 <section class="whatsnew">
-	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/1.3.html">Astropy 1.3?</a>
-	<p class="version">Current Version: 1.3.3</p>
+	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/2.0.html">Astropy 2.0?</a>
+	<p class="version">Current Version: 2.0</p>
 
 </section>
 	<section class="install">


### PR DESCRIPTION
This PR adds the release announcement for v2.0.

One semi-questionable item here: I've included the mention that this is the last 2.x-compatible version in the list of "New and improved major functionality".  It's not clear that it's literally that, but it seemed one of the best way to get people's attention - it's also mentioned in the bottom paragraph, but that's not as obvious as it seems like that should be.  But it could be put above, as well, if even more prominence is desired.

You can see this rendered at http://eteq.github.io/astropy.github.com/announcements/release-2.0.html