### PR TITLE
Add hips package to affiliated package registry.json

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -286,6 +286,15 @@
             "home_url": "http://jesford.github.io/cluster-lensing",
             "pypi_name": "cluster-lensing",
             "description": "Galaxy cluster properties and NFW profiles (with miscentering option)."
+         },
+        {
+            "name": "hips",
+            "maintainer": "Christoph Deil and Thomas Boch",
+            "stable": false,
+            "repo_url": "https://github.com/hipspy/hips",
+            "home_url": "https://hips.readthedocs.io",
+            "pypi_name": "hips",
+            "description": "A Python astronomy package for HiPS : Hierarchical Progressive Surveys."
          }
     ]
 }


### PR DESCRIPTION
It would be great if `hips` could be listed on the Astropy affiliated package list.

The core functionality is working now:
https://hips.readthedocs.io/en/latest/getting_started.html

and we'll make the v0.1 release and announce next week.