### PR TITLE
Remove WCSAxes

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -128,15 +128,6 @@
             "pypi_name": "sncosmo"
         },
         {
-            "name": "WCSAxes",
-            "maintainer": "Thomas Robitaille <thomas.robitaille@gmail.com>",
-            "provisional": false,
-            "stable": true,
-            "home_url": "http://wcsaxes.readthedocs.io",
-            "repo_url": "https://github.com/astrofrog/wcsaxes.git",
-            "pypi_name": "wcsaxes"
-        },
-        {
             "name": "Glue",
             "maintainer": "Chris Beaumont and Thomas Robitaille <thomas.robitaille@gmail.com>",
             "provisional": false,


### PR DESCRIPTION
WCSAxes is marked as deprecated on [its github repository](https://github.com/astrofrog/wcsaxes), and superceded by `astropy.visualization.wcsaxes`.
To avoid confusion, I would propose to remove it from the affiliated package list as well.