### PR TITLE
Maltpynt is now HENDRICS

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -258,14 +258,24 @@
             "pypi_name": "galpy"
         },
         {
-            "name": "MaLTPyNT",
+            "name": "HENDRICS",
             "maintainer": "Matteo Bachetti <matteo@matteobachetti.it>",
             "provisional": "2017-2-17",
             "stable": true,
-            "repo_url": "https://bitbucket.org/mbachett/maltpynt",
-            "home_url": "https://maltpynt.readthedocs.io",
-            "pypi_name": "maltpynt",
-            "description": "Quick-look timing analysis of NuSTAR data."
+            "repo_url": "https://github.com/StingraySoftware/HENDRICS",
+            "home_url": "https://hendrics.readthedocs.io",
+            "pypi_name": "hendrics",
+            "description": "Spectral-timing analysis of X-ray data from the command line (formerly known as MaLTPyNT)."
+         },
+        {
+            "name": "stingray",
+            "maintainer": "Daniela Huppenkothen, Matteo Bachetti, Abigail Stevens, Simone Migliari, and Paul Balm",
+            "provisional": false,
+            "stable": false,
+            "repo_url": "https://github.com/StingraySoftware/stingray",
+            "home_url": "https://stingray.readthedocs.io",
+            "pypi_name": "stingray",
+            "description": "Python library for spectral-timing analysis of X-ray data."
          },
         {
             "name": "Halotools",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -273,7 +273,7 @@
             "provisional": false,
             "stable": false,
             "repo_url": "https://github.com/StingraySoftware/stingray",
-            "home_url": "https://stingray.readthedocs.io",
+            "home_url": "https://stingraysoftware.github.io",
             "pypi_name": "stingray",
             "description": "Python library for spectral-timing analysis of X-ray data."
          },

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -268,16 +268,6 @@
             "description": "Spectral-timing analysis of X-ray data from the command line (formerly known as MaLTPyNT)."
          },
         {
-            "name": "stingray",
-            "maintainer": "Daniela Huppenkothen, Matteo Bachetti, Abigail Stevens, Simone Migliari, and Paul Balm",
-            "provisional": false,
-            "stable": false,
-            "repo_url": "https://github.com/StingraySoftware/stingray",
-            "home_url": "https://stingraysoftware.github.io",
-            "pypi_name": "stingray",
-            "description": "Python library for spectral-timing analysis of X-ray data."
-         },
-        {
             "name": "Halotools",
             "maintainer": "Andrew Hearin <andrew.hearin@yale.edu>",
             "provisional": false,


### PR DESCRIPTION
The provisionally accepted MaLTPyNT was renamed to HENDRICS and the API is now based on Stingray.