### PR TITLE
Add reminder about updating astropy-core-maintainers group

### DIFF
--- a/update_roles.py
+++ b/update_roles.py
@@ -118,7 +118,13 @@ if __name__ == '__main__':
 
     outlines = update_html('team.html', roles_table)
 
-    print('Replacing "team.html" with updated version.  Be sure to "git diff '
-          'team.html" before committing to ensure no funny business happened.')
+    print("""
+Replacing "team.html" with updated version.  Be sure to "git diff team.html"
+before committing to ensure no funny business happened.
+
+In addition, the astropy-core-maintainers google group MUST be updated
+to reflect changes in roles.  Send email to coordinators@astropy.org
+to generate a record of the required change.
+""")
     with open('team.html', 'w') as fh:
         fh.writelines(outlines)


### PR DESCRIPTION
Per discussion at the coordinators meeting today, we want to add a reminder that any update to roles needs to be reflected in the `astropy-core-maintainers` google group.  This list is now meant to include all those who have a role on the team page.