### PR TITLE
Mention slack on website

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -80,8 +80,17 @@
 	welcome and encouraged. These should ideally
 	be posted to our <a href="http://astropy.userecho.com/">UserEcho Forum</a>. </li>
 
-	<li>If you have feedback you would prefer to keep private, you can e-mail <a href="mailto:feedback@astropy.org">feedback@astropy.org</a>. This address points to a private mailing list that includes the astropy core developers. If you would like a reply (e.g., an acknowledgement of your comment), please request it.</li>
-	<li>For the extremely impatient, astropy developers often can be found in <a href="https://gitter.im/astropy/astropy">Astropy's gitter channel</a>. Gitter is basically a live web chat, but with features that make it better for discussing code. If you prefer using IRC clients for chat, there is <a href="https://irc.gitter.im/">a gitter to IRC bridge</a>.</li>
+	<li>If you have feedback you would prefer to keep private, you can e-mail <a
+	href="mailto:feedback@astropy.org">feedback@astropy.org</a>. This address
+	points to a private mailing list that includes the astropy core developers. If
+	you would like a reply (e.g., an acknowledgement of your comment), please
+	request it.</li>
+
+	<li>For the extremely impatient, astropy developers often can be found in the
+	<a href="https://astropy.slack.com">Astropy Slack team</a> (get an account <a
+	href="http://joinslack.astropy.org">here</a>). Slack is basically a live web
+	chat.</li>
+
 	</ul>
 
 	</section>

--- a/help.html
+++ b/help.html
@@ -77,7 +77,8 @@
 		please message one of the <a
 		href="https://www.facebook.com/groups/astropython/admins/">admins</a> with a
 		brief description of your involvement in astronomy. This is a very active
-		group and most posts get responses within a few hours.</li>
+		group and the best place for beginners/learners to get help - most posts get
+		responses within a few hours.</li>
 
 		<li><a href="http://mail.python.org/mailman/listinfo/astropy">Users Email
 		List</a> - Post questions or start discussions about anything related to
@@ -91,11 +92,12 @@
 		questions about using or contributing to astropy. Be aware that while this
 		is a live chat forum, depending on the time of day/year there may
 		not necessarily be someone available to help, so if you don't get an answer
-		here, be sure to try out one of the other methods of communication!.</li>
+		here, be sure to try out one of the other methods of communication!</li>
 
 		<li> <a href="http://groups.google.com/group/astropy-dev">Developer Email
 		List</a> - Start discussion and ask questions about changing Astropy's
-		behavior or adding new features.</li>
+		behavior or adding new features. This is also the place where significant
+		announcements for contributors/developers are usually made.</li>
 
 	</ul>
 

--- a/help.html
+++ b/help.html
@@ -60,19 +60,43 @@
 	<section>
 	<h1>Getting Help with Astropy</h1>
 
-	<p>The best way to get help is usually by asking questions to the Astropy user and development community. There are several very active forums and you are welcome to use whichever one you are the most comfortable with.</p>
+	<p>The best way to get help is usually by asking questions to the Astropy user
+	and development community. There are several very active forums and you are
+	welcome to use whichever one you are the most comfortable with.</p>
 
 	<ul>
-		<li><a href="https://twitter.com/astropy">@astropy on Twitter</a> - Mention @astropy in a tweet with your question. Your tweet may be re-tweeted in order to reach the relevant community. Many tweets get responses within a few hours.</li>
+		<li><a href="https://twitter.com/astropy">@astropy on Twitter</a> - Mention
+		@astropy in a tweet with your question. Your tweet may be re-tweeted in
+		order to reach the relevant community. Many tweets get responses within a
+		few hours.</li>
 
-		<li><a href="https://www.facebook.com/groups/astropython/">Python Users in Astronomy Facebook group</a> - Post questions or start discussions on anything related to Python programming applied to astronomy. This is a closed group. If your request to join is not approved after a couple days, please message one of the <a href="https://www.facebook.com/groups/astropython/admins/">admins</a> with a brief description of your involvement in astronomy. This is an active group and most posts get responses within a few hours.</li>
+		<li><a href="https://www.facebook.com/groups/astropython/">Python Users in
+		Astronomy Facebook group</a> - Post questions or start discussions on
+		anything related to Python programming applied to astronomy. This is a
+		closed group. If your request to join is not approved after a couple days,
+		please message one of the <a
+		href="https://www.facebook.com/groups/astropython/admins/">admins</a> with a
+		brief description of your involvement in astronomy. This is a very active
+		group and most posts get responses within a few hours.</li>
 
-		<li> <a href="https://gitter.im/astropy/astropy">Gitter channel</a> - Post quick questions and get immediate feedback on this live web chat optimized for discussing code.
-		You can sign in with either your Github or Twitter account. If you prefer using IRC clients for chat, there is <a href="https://irc.gitter.im/">a gitter to IRC bridge</a>.</li>
+		<li><a href="http://mail.python.org/mailman/listinfo/astropy">Users Email
+		List</a> - Post questions or start discussions about anything related to
+		Python programming applied to astronomy. This is an active email list and
+		most posts get a response within a few days.</li>
 
-		<li><a href="http://mail.python.org/mailman/listinfo/astropy">Users Email List</a> - Post questions or start discussions about anything related to Python programming applied to astronomy. This is an active email list and most posts get a response within a few days.</li>
+		<li> <a href="https://astropy.slack.com">Astropy Slack team</a> (get an account <a
+		href="http://joinslack.astropy.org">here</a>)- A number of developers and
+		contributors are using Slack (which has a live web chat format)
+		for everyday discussions, so please do feel free to drop by if you have
+		questions about using or contributing to astropy. Be aware that while this
+		is a live chat forum, depending on the time of day/year there may
+		not necessarily be someone available to help, so if you don't get an answer
+		here, be sure to try out one of the other methods of communication!.</li>
 
-		<li> <a href="http://groups.google.com/group/astropy-dev">Developer Email List</a> - Start discussion and ask questions about changing Astropy's behavior or adding new features.</li>
+		<li> <a href="http://groups.google.com/group/astropy-dev">Developer Email
+		List</a> - Start discussion and ask questions about changing Astropy's
+		behavior or adding new features.</li>
+
 	</ul>
 
     </section>


### PR DESCRIPTION
This replaces gitter by slack on the website. Just to explain the motivation for the change in wording, I feel like previously we made it seem too much like people would actually get an immediate reply, but I think we want to make it very clear this is not the case and that people shouldn't get frustrated if we don't reply immediately (when people use IM services they have waaaaay less patience than email lists). I'm open to suggestions though.