### PR TITLE
Fix #77: Make it easy to get links to sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -75,7 +75,7 @@
 
 
 	<section>
-	<h1>About The Astropy Project</h1>
+	<h1 id="about-the-astropy-project">About The Astropy Project<a class="paralink" href="#about-the-astropy-project" title="Permalink to this headline">¶</a></h1>
 
 	<p> The Astropy Project is a community effort to develop a core package
 	for astronomy using the
@@ -104,7 +104,7 @@
     </section>
 
     <section>
-    <h1><i>astropy</i> Core Package</h1>
+    <h1 id="astropy-core-package"><i>astropy</i> Core Package<a class="paralink" href="#astropy-core-package" title="Permalink to this headline">¶</a></h1>
 
     <p>The <i>astropy</i> package (alternatively known as the "core" package)
     contains various classes, utilities, and a packaging framework intended
@@ -119,7 +119,7 @@
     </section>
 
     <section>
-    <h1>Affiliated Packages</h1>
+    <h1 id="affiliated-packages">Affiliated Packages<a class="paralink" href="#affiliated-packages" title="Permalink to this headline">¶</a></h1>
 
     <p>The Astropy project includes the concept of "affiliated packages." An
     affiliated package is an astronomy-related python package that is not
@@ -161,14 +161,14 @@
 	<section>
 		<a name="license"></a>
 
-		<h1>License</h1>
+		<h1 id="license">License<a class="paralink" href="#license" title="Permalink to this headline">¶</a></h1>
 
 		<p>Astropy is licensed under a <a href="http://opensource.org/licenses/BSD-3-Clause">three-clause BSD license</a>.  For details, see the <a href="https://github.com/astropy/astropy/blob/master/LICENSE.rst" target="_blank">LICENSE.rst</a> file in the astropy repository.</p>
 	</section>
 
     <section>
 
-		<h1>Fiscal Sponsor</h1>
+		<h1 id="fiscal-sponsor">Fiscal Sponsor<a class="paralink" href="#fiscal-sponsor" title="Permalink to this headline">¶</a></h1>
 
 		<p>The Astropy Project is fiscally sponsored by <a href="http://www.numfocus.org/">NumFOCUS</a></p>
 		<a href="https://www.numfocus.org"><img width="299" src="images/Numfocus_stamp.png"></a>

--- a/acknowledging.html
+++ b/acknowledging.html
@@ -119,7 +119,7 @@ Bdsk-Url-1 = {https://doi.org/10.3847/1538-3881/aabc4f}}`;
 	<section>
 		<a name="acknowledge"></a>
 
-		<h1>Acknowledging or Citing Astropy</h1>
+		<h1 id="acknowledging-or-citing-astropy">Acknowledging or Citing Astropy<a class="paralink" href="#acknowledging-or-citing-astropy" title="Permalink to this headline">¶</a></h1>
 
 		<h2>In Publications</h2>
 

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -71,7 +71,7 @@
 
 
 
-	<h1>Astropy Affiliated Packages</h1>
+	<h1 id="affiliated-packages">Astropy Affiliated Packages<a class="paralink" href="#affiliated-packages" title="Permalink to this headline">¶</a></h1>
 
 	<p>A major part of the Astropy Project is the concept of “Astropy
 	affiliated packages”. An affiliated package is an astronomy-related Python
@@ -87,7 +87,7 @@
 	details are in the <a href="#affiliated-instructions">Becoming an
 	Affiliated Package</a> section.</p>
 
-	<h1>Astropy Coordinated Packages</h1>
+	<h1 id="coordinated-packages">Astropy Coordinated Packages<a class="paralink" href="#coordinated-packages" title="Permalink to this headline">¶</a></h1>
 
 	<p>A related concept is that of “Astropy coordinated packages”. Coordinated
 	packages are similar to affiliated packages, but the Astropy Project as a
@@ -101,10 +101,10 @@
     space-focused), while others started as affiliated packages but have become
     so important to the ecosystem that they grew to become coordinated.</p>
 
-	<h2>Astropy Infrastructure Packages</h2>
+	<h2 id="infrastructure-packages">Astropy Infrastructure Packages<a class="paralink" href="#infrastructure-packages" title="Permalink to this headline">¶</a></h2>
 
-	<p>One final related category are the "Astropy infrastructure packages". 
-	These packages are those that are necessary infrastructure for Astropy 
+	<p>One final related category are the "Astropy infrastructure packages".
+	These packages are those that are necessary infrastructure for Astropy
 	packages - e.g. testing and documentation machinery.  While occasionally
 	these have astro-specific functionality, in general they are more generic
 	packages that are useful to packages outside of astronomy, and as a result
@@ -117,7 +117,7 @@
 
 	<section id="installing">
 
-	<h1>Installing Affiliated and Coordinated Packages</h1>
+	<h1 id="installing-affiliated-packages">Installing Affiliated and Coordinated Packages<a class="paralink" href="#installing-affiliated-packages" title="Permalink to this headline">¶</a></h1>
 
 	<p>  The simplest way to install and keep up-to-date most affiliated packages is to use the <a href="https://www.continuum.io/why-anaconda">Anaconda python distribution</a>.  This distribution includes the <a href="http://astropy.readthedocs.io/en/stable/index.html">Astropy core package</a> already built in, and you can then easily install or update affiliated packages using the <a href="https://anaconda.org/astropy/packages">Astropy Conda channel</a> of binary installable packages.  Once you have Anaconda installed, you can do <code>conda search --channel astropy some_affiliated_package</code>.  Most importantly, you can then install them with <code>conda install --channel astropy some_affiliated_package</code>.  The Astropy channel is maintained by the Astropy Project on Github via code in the <a href="https://github.com/astropy/conda-channel-astropy">conda-channel-astropy</a> repository. </p>
 
@@ -126,7 +126,7 @@
 	</section>
 
 	<section id="coordinated-package-registry">
-	  <h1>Coordinated Packages</h1>
+	  <h1>Coordinated Packages<a class="paralink" href="#coordinated-packages-registry" title="Permalink to this headline">¶</a></h1>
 	  <p>The following table lists all current Astropy coordinated packages. They are determined from the <a href="http://www.astropy.org/affiliated/registry.json">json file</a>, which is the actual authoritative registry.</p>
 <!--	  <h3><u>Affiliated Packages</u></h3>-->
       <p>Total number of coordinated packages: <strong id="total-coordinated-pkgs"></strong></p>
@@ -163,7 +163,7 @@
 	</section>
 
 	<section id="affiliated-package-registry">
-	  <h1>Affiliated Packages Registry</h1>
+	  <h1>Affiliated Packages Registry<a class="paralink" href="#affiliated-packages-registry" title="Permalink to this headline">¶</a></h1>
 	  <p>The following table lists all currently registered affiliated packages. They are determined from the <a href="http://www.astropy.org/affiliated/registry.json">json file</a>, which is the actual authoritative registry.</p>
 <!--	  <h3><u>Affiliated Packages</u></h3>-->
       <p>Total number of affiliated packages: <strong id="total-affiliated-pkgs"></strong></p>
@@ -201,7 +201,7 @@
 
 	<section id="affiliated-instructions">
 
-	<h1>Becoming an Affiliated Package</h1>
+	<h1 id="becoming-an-affiliated-package">Becoming an Affiliated Package<a class="paralink" href="#becoming-an-affiliated-package" title="Permalink to this headline">¶</a></h1>
 
 	<p>If you are a developer of an astronomy package and would like your package
 	to become affiliated with the Astropy Project, please take a look at the

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -101,7 +101,7 @@
     space-focused), while others started as affiliated packages but have become
     so important to the ecosystem that they grew to become coordinated.</p>
 
-	<h2 id="infrastructure-packages">Astropy Infrastructure Packages<a class="paralink" href="#infrastructure-packages" title="Permalink to this headline">¶</a></h2>
+	<h1 id="infrastructure-packages">Astropy Infrastructure Packages<a class="paralink" href="#infrastructure-packages" title="Permalink to this headline">¶</a></h1>
 
 	<p>One final related category are the "Astropy infrastructure packages".
 	These packages are those that are necessary infrastructure for Astropy
@@ -126,7 +126,7 @@
 	</section>
 
 	<section id="coordinated-package-registry">
-	  <h1>Coordinated Packages<a class="paralink" href="#coordinated-packages-registry" title="Permalink to this headline">¶</a></h1>
+	  <h1 id="coordinated-package-list">Coordinated Packages<a class="paralink" href="#coordinated-package-list" title="Permalink to this headline">¶</a></h1>
 	  <p>The following table lists all current Astropy coordinated packages. They are determined from the <a href="http://www.astropy.org/affiliated/registry.json">json file</a>, which is the actual authoritative registry.</p>
 <!--	  <h3><u>Affiliated Packages</u></h3>-->
       <p>Total number of coordinated packages: <strong id="total-coordinated-pkgs"></strong></p>
@@ -163,7 +163,7 @@
 	</section>
 
 	<section id="affiliated-package-registry">
-	  <h1>Affiliated Packages Registry<a class="paralink" href="#affiliated-packages-registry" title="Permalink to this headline">¶</a></h1>
+	  <h1 id="affiliated-package-list">Affiliated Packages Registry<a class="paralink" href="#affiliated-package-list" title="Permalink to this headline">¶</a></h1>
 	  <p>The following table lists all currently registered affiliated packages. They are determined from the <a href="http://www.astropy.org/affiliated/registry.json">json file</a>, which is the actual authoritative registry.</p>
 <!--	  <h3><u>Affiliated Packages</u></h3>-->
       <p>Total number of affiliated packages: <strong id="total-affiliated-pkgs"></strong></p>
@@ -267,7 +267,7 @@
 	Note however that if packages become unmaintained or do not meet the standards
 	anymore, they may be removed from the list of affiliated packages.</p>
 
-	<h2>Package Template</h2>
+	<h2 id="package-template">Package Template<a class="paralink" href="#package-template" title="Permalink to this headline">¶</a></h2>
 	<p>If you are considering creating a new astronomy package and would like it
 	to be an Astropy affiliated package, we provide a <a
 	href="https://github.com/astropy/package-template">package template</a> to

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -74,7 +74,7 @@
 	<section>
 		<a name="codeofconduct"></a>
 
-		<h1>Astropy Community Code of Conduct</h1>
+		<h1 id="astropy-community-code-of-conduct">Astropy Community Code of Conduct<a class="paralink" href="#astropy-community-code-of-conduct" title="Permalink to this headline">¶</a></h1>
 
 		<p>The community of participants in open source Astronomy projects is made
 		up of members from around the globe with a diverse set of skills,

--- a/contribute.html
+++ b/contribute.html
@@ -134,7 +134,7 @@
 
 
 	<section id="code">
-		<h2>Contribute code or documentation</h2>
+		<h2 id="contribute-code-or-docs">Contribute code or documentation<a class="paralink" href="#contribute-code-or-docs" title="Permalink to this headline">¶</a></h2>
 
 		<p>If you are interested in contributing fixes, code or documentation to Astropy (whether the core package or affiliated packages), you should join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> mailing list/forum, and start looking at any related <a href="https://github.com/astropy/astropy/issues">issues</a>. In particular, we have introduced a labeling system used across most Astropy-related packages which will allow you to find good starting issues.  A good label to start with is <a href="https://github.com/search?p=2&q=label%3Apackage-novice&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-package">Package-novice</a> which means you don't need much prior experience of the package. You can use the following links to find all the issues labelled this way and also labeled by how much work they involve:</p>
     <ul>
@@ -152,7 +152,7 @@
 	</section>
 
 	<section id="affiliated">
-		<h2>Develop an affiliated package</h2>
+		<h2 id="develop-affiliated-package">Develop an affiliated package<a class="paralink" href="#develop-affiliated-package" title="Permalink to this headline">¶</a></h2>
 
 		<p>Whether you have an idea for a new Astronomy package, or already have a package that you want to integrate with the Astropy project, you can develop an affiliated package! You'll want to join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> list so you can notifying other developers of your intent to develop an affiliated package, and the <a href="https://groups.google.com/forum/#!forum/astropy-affiliated-maintainers">astropy-affiliated-maintainers</a> mailing list to be kept informed of updates to the package template, as well as to have any dicussions related to setting up affiliated packages.  Then you can check out the <a href="affiliated/index.html#affiliated-instructions">affiliated package guidelines</a> and the <a href="http://github.com/astropy/package-template">template for new affiliated packages</a> to get started. We can even create a repository for your affiliated package in the astropy organization on GitHub, if you ask on the mailing list!</p>
 
@@ -160,7 +160,7 @@
 	</section>
 
 	<section id="donate">
-		<h2>Contribute Financially</h2>
+		<h2 id="contribute-financially">Contribute Financially<a class="paralink" href="#develop-affiliated-package" title="Permalink to this headline">¶</a></h2>
 
 		<p>Astropy is fiscally represented by <a href="https://numfocus.org/">NumFOCUS</a>, which accepts donations to support development of Astropy.  If you would like to donate to astropy, please see the NumFOCUS contribution page for the Astropy Project:</p>
 		<a class="button" href="https://numfocus.salsalabs.org/donate-to-astropy/index.html" target="_blank">Donate to Astropy</a>

--- a/contribute.html
+++ b/contribute.html
@@ -70,14 +70,14 @@
 	</nav>
 
 	<section>
-		<h1>Contribute to Astropy</h1>
+		<h1 id="contribute-to-astropy">Contribute to Astropy<a class="paralink" href="#contribute-to-astropy" title="Permalink to this headline">¶</a></h1>
 
 		<p>The Astropy project is made both by and for its users, so we accept contributions of many kinds. We always welcome contributors who will abide by the <a href="about.html#codeofconduct">Astropy Community Code of Conduct</a>.</p>
 
 	</section>
 
 	<section id="feedback">
-		<h1>Contribute feedback</h1>
+		<h1 id="contribute-feedback">Contribute feedback<a class="paralink" href="#contribute-feedback" title="Permalink to this headline">¶</a></h1>
 
 	<p>There are several ways in which you can give feedback. </p>
 
@@ -106,7 +106,7 @@
 
 
     <section>
-    <h1>Reporting Issues</h1>
+    <h1 id="reporting-issues">Reporting Issues<a class="paralink" href="#reporting-issues" title="Permalink to this headline">¶</a></h1>
 
     <p>If you have found a bug in Astropy please report it. The preferred way is to
     create a new issue on the Astropy

--- a/css/style.css
+++ b/css/style.css
@@ -130,6 +130,7 @@ a.paralink{
     font-size: 0.8em;
     padding: 0 4px 0 4px;
     text-decoration: none;
+		opacity: 0.8;
     visibility: hidden;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -126,6 +126,19 @@ a:hover{
 	color:#333;
 }
 
+a.paralink{
+    font-size: 0.8em;
+    padding: 0 4px 0 4px;
+    text-decoration: none;
+    visibility: hidden;
+}
+
+a.paralink:hover{
+    background-color: #FF5000;
+    color: white;
+    text-decoration: none;
+}
+
 h1{
 	font-size: 24px;
 	margin-top: 10px;

--- a/help.html
+++ b/help.html
@@ -69,7 +69,7 @@
 	</nav>
 
 	<section>
-	<h1>Getting Help with Astropy</h1>
+	<h1 id="getting-help-with-astropy">Getting Help with Astropy<a class="paralink" href="#getting-help-with-astropy" title="Permalink to this headline">¶</a></h1>
 
 	<p>The best way to get help is usually by asking questions to the Astropy user
 	and development community. There are several very active forums and you are

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 </section>
 
 	<section class="install">
-	  <h1>Install Astropy</h1>
+		<h1 id="install-astropy">Install Astropy<a class="paralink" href="#install-astropy" title="Permalink to this headline">¶</a></h1>
 	  The <a href="https://www.anaconda.com/download/">Anaconda
 	    Python Distribution</a> includes astropy and is the recommended way to install both
 	  Python and the astropy package. Once you have Anaconda
@@ -101,7 +101,7 @@
 	</section>
 
 	<section class="whatsnext">
-		<h1>Learn Astropy</h1>
+		<h1 id="learn-astropy">Learn Astropy<a class="paralink" href="#learn-astropy" title="Permalink to this headline">¶</a></h1>
 		<p>You can explore the functionality available in Astropy by checking out the <a href="http://docs.astropy.org/en/stable/generated/examples/">Example Gallery, <a href="http://tutorials.astropy.org">Tutorials</a>, and <a
 		href="http://docs.astropy.org">Documentation</a>.</p>
 		<a class="button" href="http://docs.astropy.org/en/stable/generated/examples/index.html" target="_blank">Example Gallery</a>
@@ -110,21 +110,21 @@
 	</section>
 
 	<section class="whatsnext">
-		<h1>Get Help</h1>
+		<h1 id="get-help">Get Help<a class="paralink" href="#get-help" title="Permalink to this headline">¶</a></h1>
 		<p>If you have any questions regarding using Astropy there are numerous channels for communication. Post to any one of several forums to get help from our active, helpful, and friendly community of users and developers.
 		</p>
 		<a class="button" href="help.html" target="_blank">Get Help</a>
 	</section>
 
 	<section class="whatsnext">
-		<h1>Report bugs and Contribute</h1>
+		<h1 id="report-bugs-and-contribute">Report bugs and Contribute<a class="paralink" href="#report-bugs-and-contribute" title="Permalink to this headline">¶</a></h1>
 		<p>If you encounter something you believe to be a mistake, error, or bug, the best way to get it addressed is to report it on the <a href="http://github.com/astropy/astropy/issues">github issue tracker</a>. If you aren't sure if something is a bug or not, or if you don't have a Github account, feel free to ask on one of the <a href="help.html">forums</a>. If you believe you know how to fix the problem, please consider <a href="contribute.html#code">contributing</a>!</p>
 		<a class="button" href="https://github.com/astropy/astropy/issues" target="_blank">Report issues</a>
 		<a class="button" href="contribute.html" target="_blank">Contribute</a>
 	</section>
 
 	<section class="cite">
-		<h1>Support Astropy</h1>
+		<h1 id="support-astropy">Support Astropy<a class="paralink" href="#support-astropy" title="Permalink to this headline">¶</a></h1>
 		<p>If you use Astropy in your work, we would be grateful if you could include an acknowledgment in papers and/or presentations. See <a href="acknowledging.html">Acknowledging & Citing Astropy</a> for details. </p>
 		<p>You can also purchase apparel and trinkets from <a href="http://fashion.astropy.org">fashion.astropy.org</a>, and a portion of the profits go to support the project!</p>
 		<p> If you are interested in directly financially supporting Astropy (either one-time or recurring), you can do so via our fiscal sponsor NumFOCUS: </p>

--- a/js/functions.js
+++ b/js/functions.js
@@ -223,6 +223,17 @@ $( document ).ready(function(){
     }, function() {
         $(this).children("a").css("visibility", "hidden");
     });
+    $("h2").hover(function() {
+        $(this).children("a").css("visibility", "visible");
+    }, function() {
+        $(this).children("a").css("visibility", "hidden");
+    });
+    $("h3").hover(function() {
+        $(this).children("a").css("visibility", "visible");
+    }, function() {
+        $(this).children("a").css("visibility", "hidden");
+    });
+
 }); // Document Ready
 
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -217,7 +217,7 @@ $( document ).ready(function(){
         });
     });
 
-    //making permalink visible only when user moves cursor on headline, otherwise hidden
+    // makes permalink visible only when user moves cursor on headline, otherwise hidden
     $("h1").hover(function() {
         $(this).children("a").css("visibility", "visible");
     }, function() {

--- a/js/functions.js
+++ b/js/functions.js
@@ -216,6 +216,13 @@ $( document ).ready(function(){
             });
         });
     });
+
+    //making permalink visible only when user moves cursor on headline, otherwise hidden
+    $("h1").hover(function() {
+        $(this).children("a").css("visibility", "visible");
+    }, function() {
+        $(this).children("a").css("visibility", "hidden");
+    });
 }); // Document Ready
 
 

--- a/team.html
+++ b/team.html
@@ -72,7 +72,7 @@
 	</nav>
 
 	<section>
-        <h1> Astropy Team </h1>
+        <h1 id="astropy-team"> Astropy Team<a class="paralink" href="#astropy-team" title="Permalink to this headline">¶</a> </h1>
 
 		<h2 id="roles">Roles</h2>
 

--- a/team.html
+++ b/team.html
@@ -74,7 +74,7 @@
 	<section>
         <h1 id="astropy-team"> Astropy Team<a class="paralink" href="#astropy-team" title="Permalink to this headline">¶</a> </h1>
 
-		<h2 id="roles">Roles</h2>
+		<h2 id="roles">Roles<a class="paralink" href="#roles" title="Permalink to this headline">¶</a></h2>
 
 		<p>The Astropy project is made possible through the efforts of
 		community members that perform numerous important roles.  This
@@ -112,7 +112,7 @@
 	</section>
 
 	<section>
-	<h2 id="role-responsibilities">Astropy Project Role Responsibilities</h2>
+	<h2 id="role-responsibilities">Astropy Project Role Responsibilities<a class="paralink" href="#role-responsibilities" title="Permalink to this headline">¶</a></h2>
 
 	<p>The Astropy project is made possible through the efforts of
 	community members that perform numerous important roles.  This
@@ -127,11 +127,11 @@
 	</section>
 
 	<section>
-		<h2>Contributors</h2>
+		<h2 id="contributors">Contributors<a class="paralink" href="#contributors" title="Permalink to this headline">¶</a></h2>
 
 		<p>Astropy project packages are under continuous development by professional astronomers and software developers from around the world. The Project is community-driven, with decisions generally made by consensus, but with oversight and organization provided by the coordinating committee.</p>
 
-		<h3>Core Package Contributors</h3>
+		<h3 id="core-package-contributors">Core Package Contributors<a class="paralink" href="#core-package-contributors" title="Permalink to this headline">¶</a></h3>
 
 		<ul class="team">
 <li>  Ryan Abernathey </li>
@@ -455,7 +455,7 @@
 <li>  Noah Zuckman </li>
 		</ul>
 
-		<h3>Other Credits</h3>
+		<h3 id="other-credits">Other Credits<a class="paralink" href="#other-credits" title="Permalink to this headline">¶</a></h3>
 
 		<ul>
 		   <li>Kaylea Nelson for designing this web site.</li>


### PR DESCRIPTION
Fixes #77 (for about page only at the moment)
Since this is from a branch on my fork, I can't generate a preview on Github pages, as it's allowed from the master branch only. One way to see the changes _locally_ would be as follows:
1) Clone my repo from [https://github.com/apooravc/astropy.github.com](https://github.com/apooravc/astropy.github.com)
2) After cloning, only the master branch would be available locally. Enter `git checkout -b add-section-link origin/add-section-link` to get the branch _add-section-link_ locally.
3) The changes could then be seen on the about page.

@astrofrog @eteq Please have a look.