### PR TITLE
Fix #105: Place the NumFOCUS digital stamp on astropy home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -29,8 +29,8 @@ footer, header, hgroup, menu, nav, section {
 	display: block;
 }
 .footer {
-	color: white;
-	background-color: #1a1a1a;
+	color: black;
+	background-color: #f5f5f5;
 	position: relative;
 }
 .footer-text {

--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,39 @@ article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
+.footer {
+	color: white;
+	background-color: #1a1a1a;
+	position: relative;
+}
+.footer-text {
+	width: 50%;
+	padding: 12px 12px;
+}
+.footer-text a:hover {
+	color: #FF851B;
+}
+.footer-stamp {
+	position: absolute;
+	top: 20px;
+	right: 10px;
+}
+@media (max-width: 710px) {
+  .footer-text {
+	width: 40%;
+	padding: 12px 6px;
+  }
+}
+@media (max-width: 593px) {
+  .footer-text {
+	width: 90%;
+	padding: 12px 12px;
+  }
+  .footer-stamp {
+	position: static;
+	margin: 13px;
+  }
+}
 body {
 	line-height: 1;
 }

--- a/index.html
+++ b/index.html
@@ -137,16 +137,19 @@
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 		<script src="js/jquery.sidr.min.js"></script>
 		<script src="js/functions.js"></script>
-
-		<hr>
-		<p>
-		<img style="vertical-align:middle" src="images/astropy_brandmark.png" height=20><span style="vertical-align:middle">
-        <a href="code_of_conduct.html"> The Astropy project is committed to fostering an inclusive community</a></span>.
-        </p>
-
 	</footer>
-
 </div>
 
+<div class="footer">
+	<div class="footer-text">
+		<h2>
+			<img style="vertical-align:middle" src="images/astropy_brandmark.png" height="40px">
+			<span style="vertical-align:middle">Code of Conduct</span>
+		</h2>
+		<hr>
+	    <p>The Astropy project is committed to fostering an inclusive community. The community of participants in open source Astronomy projects is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences success and continued growth. <a href="code_of_conduct.html">Learn more</a></p>
+	</div>
+	<img src="images/Numfocus_stamp.png" class="footer-stamp">
+</div>
 </body>
 </html>


### PR DESCRIPTION
Fixes #105 
Added a footer on home page, combining Astropy Code of Conduct and NumFOCUS stamp.
Preview:
![img1](https://user-images.githubusercontent.com/25399108/36031188-eb71471c-0dcf-11e8-8fe1-40bae06cbe39.JPG)

The layout is adaptive for a good range of browser screen width. One way to see the changes _locally_ would be as follows:
1) Clone my repo from [https://github.com/apooravc/astropy.github.com](https://github.com/apooravc/astropy.github.com)
2) After cloning, only the master branch would be available locally. Enter `git checkout -b add-footer origin/add-footer` to get the branch _add-footer_ locally.
3) The changes could then be seen on home page.

@astrofrog @kelle @eteq Please have a look.