### PR TITLE
Add 3.0 release announcement

### DIFF
--- a/acknowledging.html
+++ b/acknowledging.html
@@ -67,12 +67,16 @@
 
 		<h3>In Publications</h3>
 
-		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you cite the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
-		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).
+		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you cite the <a href="https://arxiv.org/abs/1801.02634" target="_blank">Astropy Paper II</a> (<a href="http://adsabs.harvard.edu/abs/2018arXiv180102634T" target="_blank">ADS</a> -
+		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180102634T&data_type=BIBTEX&db_key=PRE&nocookieset=1" target="_blank">BibTeX</a>).</p>
         We provide the following as a standard  acknowledgment you can use if there is not a specific place to cite the paper:</p>
 
-		<p class="citation"><cite>This research made use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2013).</cite></p>
+		<p class="citation"><cite>This research made use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2018).</cite></p>
 
+        <p> This paper is still under review, however, and an earlier paper is available
+		describing the status of the package at the time of v0.2. If your work has 
+		used Astropy since then, you can instead cite <cite>(Astropy Collaboration, 2013, 2018)</cite>  where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">first Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
+		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).</p>
 		<p>If you wish, you can also include a link to <cite>http://www.astropy.org</cite> (if the journal allows this) in addition to the above text.</p>
 
 		<h3>In Presentations</h3>

--- a/announcements/release-3.0.html
+++ b/announcements/release-3.0.html
@@ -169,9 +169,9 @@ pip install astropy --upgrade
 		<p>where <cite>(Astropy Collaboration, 2018)</cite> is a citation to the <a href="https://arxiv.org/abs/1801.02634" target="_blank">Astropy Paper II</a> (<a href="http://adsabs.harvard.edu/abs/2018arXiv180102634T" target="_blank">ADS</a> -
 		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180102634T&data_type=BIBTEX&db_key=PRE&nocookieset=1" target="_blank">BibTeX</a>).</p>
 		<p>
-		An earlier paper is also available describing the status of the package at
-		the time of v0.2. If your work has used Astropy since then, you are
-		encouraged to acknowledge both papers:
+		This paper is still under review, however, and an earlier paper is available
+		describing the status of the package at the time of v0.2. If your work has 
+		used Astropy since then, you are encouraged to acknowledge both papers:
 	  </p>
 
 		<p class="citation"><cite>This research made use of Astropy, a

--- a/announcements/release-3.0.html
+++ b/announcements/release-3.0.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="description" content="Astropy. A Community Python Library for Astronomy." />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="shortcut icon" href="favicon.ico" />
+
+<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css' />
+<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+<link rel="stylesheet" type="text/css" href="../css/style.css" />
+<link rel="stylesheet" type="text/css" href="../css/jquery.sidr.light.css" />
+
+
+<title>Astropy | v3.0 Released!</title>
+
+<!-- Google analytics -->
+<script src="../js/analytics.js"></script>
+</head>
+
+<body>
+
+<div id="wrapper">
+	<nav>
+		<div id="mobile-header">
+			<!-- Menu Icon -->
+		    <a id="responsive-menu-button" href="#sidr-main"><div><svg senable-background="new 0 0 24 24" height="24px" id="Layer_1" version="1.1" viewBox="0 0 24 24" width="24px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g><g><path d="M23.244,17.009H0.75c-0.413,0-0.75,0.36-0.75,0.801v3.421C0,21.654,0.337,22,0.75,22h22.494c0.414,0,0.75-0.346,0.75-0.77    V17.81C23.994,17.369,23.658,17.009,23.244,17.009z M23.244,9.009H0.75C0.337,9.009,0,9.369,0,9.81v3.421    c0,0.424,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.345,0.75-0.769V9.81C23.994,9.369,23.658,9.009,23.244,9.009z     M23.244,1.009H0.75C0.337,1.009,0,1.369,0,1.81V5.23c0,0.423,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.346,0.75-0.769V1.81    C23.994,1.369,23.658,1.009,23.244,1.009z"/></g></g></svg></div></a>
+		    <!-- -->
+		</div>
+		<a href="../index.html"><img src="../images/astropy_word.svg" height="32" onerror="this.src='../images/astropy_word_32.png; this.onerror=null;"/></a>
+		<div id="navigation">
+			<ul>
+				<li>
+					<div class="dropdown">
+						<a>About</a>
+						<div class="dropdown-content">
+							<ul>
+								<li><a href="../about.html">About Astropy</a></li>
+								<li><a href="../code_of_conduct.html">Code of Conduct</a></li>
+								<li><a href="../acknowledging.html">Acknowledging</a></li>
+							</ul>
+						</div>
+					</div>
+				</li>
+				<li><a href="../help.html">Get Help</a></li>
+				<li><a href="../contribute.html">Contribute</a></li>
+				<li>
+					<div class="dropdown">
+						<a href="http://docs.astropy.org">Documentation</a>
+						<div class="dropdown-content">
+							<ul>
+								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
+								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.2.2/index.html" target="_blank">v1.2.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.1.2/index.html" target="_blank">v1.1.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.0.13/index.html" target="_blank">v1.0.13</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.4.6/index.html" target="_blank">v0.4.6</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.3.2/index.html" target="_blank">v0.3.2</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.2.5/index.html" target="_blank">v0.2.5</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v0.1/index.html" target="_blank">v0.1</a></li>
+							</ul>
+						</div>
+					</div>
+				</li>
+				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
+				<li><a href="team.html">Team</a></li>
+			</ul>
+		</div>
+		<div class="search pull-right">
+			<form action="http://docs.astropy.org/en/stable/search.html" method="get">
+			  <input type="text" name="q" placeholder="Search Documentation" />
+			  <input type="hidden" name="check_keywords" value="yes" />
+			  <input type="hidden" name="area" value="default" />
+			</form>
+		</div>
+	</nav>
+
+
+	<section>
+
+		<h1>Astropy v3.0 Released!</h1>
+
+		<p>
+		Dear colleagues,
+		</p>
+		<p>
+		We are very happy to announce the v3.0 release of the Astropy package,
+		a core Python package for Astronomy:
+		</p>
+		<p align='center'>
+		    <img src="astropy_logo_notext.png" style="width:80px;height:80px;"><br>
+		    <a href="http://www.astropy.org">http://www.astropy.org</a>
+		</p>
+		<p>
+		Astropy is a community-driven Python package intended to contain much of the
+		core functionality and common tools needed for astronomy and astrophysics.
+		It is part of the Astropy Project, which aims to foster an ecosystem of
+		interoperable astronomy packages for Python.
+		</p>
+		<p>
+		New and improved major functionality in this release includes:
+		<ul>
+			<li>Full support for velocities in the coordinates subpackage, including SkyCoord objects and proper motion corrections.</li>
+			<li>Very large ASCII files can now be read in as chunks, allowing larger tables to be efficiently read in, along with other performance improvements reading tables.</li>
+			<li>Time objects can now be read from or written to FITS files following the official FITS time standard. </li>
+			<li>Table mixin columns (e.g., quantities) can now be losslessly saved to HDF5 or FITS tables.</li>
+			<li>Constants can now be versioned using context managers.</li>
+			<li>Support for quantities in scipy special functions</li>
+			<li>A new command line script, "showtable", is available to display tables from any format Astropy can read.</li>
+			<li>The pytest plugins for testing Astropy have been moved to external packages, enabling their use in a wider range of Python packages.</li>
+			<li>False alarm probabilities are now available for the Lomb-Scargle periodogram implementation.</li>
+		</ul>
+		</p>
+		<p>
+		In addition, hundreds of smaller improvements and fixes have been made. An overview of the changes is provided at:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://docs.astropy.org/en/stable/whatsnew/3.0.html">http://docs.astropy.org/en/stable/whatsnew/3.0.html</a>
+		</p>
+		<p>
+		Note that the Astropy 3.x series is the first to only support Python 3.  Python 2 users can continue to use the 2.x series, which will receive bug fixes and support until the Python developers permanently sunset Python 2.7  (scheduled for 2019).
+		</p>
+		<p>
+		Instructions for installing Astropy are provided on our <a
+		href="http://www.astropy.org">website</a>, and extensive documentation can be
+		found at:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://docs.astropy.org">http://docs.astropy.org</a>
+		</p>
+		<p>
+		If you make use of the <a href="https://www.continuum.io/downloads">Anaconda
+		Python Distribution</a>, you can update to Astropy v3.0 with:
+		</p>
+<pre>
+conda update astropy
+</pre>
+		<p>
+		  Whereas if you usually use pip, you can do:
+		</p>
+<pre>
+pip install astropy --upgrade
+</pre>
+		<p>
+		Please report any issues, or request new features via our GitHub repository:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/astropy/astropy/issues">https://github.com/astropy/astropy/issues</a>
+		</p>
+		<p>
+		Over 253 developers have contributed code to Astropy so far, and you can find out more about the team behind Astropy here:
+		</p>
+		<p>
+		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://www.astropy.org/team.html">http://www.astropy.org/team.html</a>
+		</p>
+		<p>
+			As a reminder, Astropy v2.0 (our long term support release) will continue to be supported with bug fixes until the end 2019, so if you need to use Astropy in a very stable environment, you may want to consider staying on the v2.0.x set of releases (for which we have recently released v2.0.4).
+
+		</p>
+		<p>
+		If you use Astropy directly for your work, or as a dependency to another
+		package, please remember to include the following acknowledgment at the end of
+		papers:
+		</p>
+		<p class="citation"><cite>This research made use of Astropy, a
+		community-developed core Python package for Astronomy (Astropy Collaboration,
+		2018).</cite></p>
+
+		<p>where <cite>(Astropy Collaboration, 2018)</cite> is a citation to the <a href="https://arxiv.org/abs/1801.02634" target="_blank">Astropy Paper II</a> (<a href="http://adsabs.harvard.edu/abs/2018arXiv180102634T" target="_blank">ADS</a> -
+		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180102634T&data_type=BIBTEX&db_key=PRE&nocookieset=1" target="_blank">BibTeX</a>).</p>
+		<p>
+		An earlier paper is also available describing the status of the package at
+		the time of v0.2. If your work has used Astropy since then, you are
+		encouraged to acknowledge both papers:
+	  </p>
+
+		<p class="citation"><cite>This research made use of Astropy, a
+		community-developed core Python package for Astronomy (Astropy Collaboration,
+		2013, 2018).</cite></p>
+
+		<p>where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
+		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).</p>
+
+
+		<p>
+		Special thanks to the coordinator for this release: Brigitta Sipocz.
+		</p>
+		<p>
+		We hope that you enjoy using Astropy as much as we enjoyed developing it!
+		</p>
+		<p>
+		Erik Tollerud, Tom Robitaille, Kelle Cruz, and Tom Aldcroft<br>
+		on behalf of The Astropy Collaboration
+		</p>
+	</section>
+
+
+
+	<footer>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+		<script src="js/jquery.sidr.min.js"></script>
+		<script src="js/functions.js"></script>
+	</footer>
+
+</div>
+
+</body>
+</html>

--- a/announcements/release-3.0.html
+++ b/announcements/release-3.0.html
@@ -178,7 +178,7 @@ pip install astropy --upgrade
 		community-developed core Python package for Astronomy (Astropy Collaboration,
 		2013, 2018).</cite></p>
 
-		<p>where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
+		<p>where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="http://dx.doi.org/10.1051/0004-6361/201322068" target="_blank">first Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
 		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).</p>
 
 

--- a/index.html
+++ b/index.html
@@ -85,8 +85,8 @@
   </section>
 
 <section class="whatsnew">
-	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/2.0.html">Astropy 2.0?</a>
-	<p class="version">Current Version: 2.0.3</p>
+	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/3.0.html">Astropy 3.0?</a>
+	<p class="version">Current Version: 3.0</p>
 
 </section>
 

--- a/team.html
+++ b/team.html
@@ -583,239 +583,264 @@
 		<h3>Core Package Contributors</h3>
 
 		<ul class="team">
-			<li>Ryan Abernathey</li>
-			<li>Shailesh Ahuja</li>
-			<li>Tom Aldcroft</li>
-			<li>Anne Archibald</li>
-			<li>Cristian Ardelean</li>
-			<li>Tomas Babej</li>
-			<li>Matteo Bachetti</li>
-			<li>Steven Bamford</li>
-			<li>Kyle Barbary</li>
-			<li>Geert Barentsen</li>
-			<li>Pauline Barmby</li>
-			<li>Paul Barrett</li>
-			<li>Andreas Baumbach</li>
-			<li>Chris Beaumont</li>
-			<li>Daniel Bell</li>
-			<li>Elijah Bernstein-Cooper</li>
-			<li>Kristin Berry</li>
-			<li>Edward Betts</li>
-			<li>Mavani Bhautik</li>
-			<li>Francesco Biscani</li>
-			<li>Thompson Le Blanc</li>
-			<li>Christopher Bonnett</li>
-			<li>Joseph Jon Booker</li>
-			<li>Médéric Boquien</li>
-			<li>Azalee Bostroem</li>
-			<li>Luke G. Bouma</li>
-			<li>Matthew Bourque</li>
-			<li>Larry Bradley</li>
-			<li>Gustavo Bragança</li>
-			<li>Gabriel Brammer</li>
-			<li>Erik M. Bray</li>
-			<li>Eli Bressert</li>
-			<li>Matthew Brett</li>
-			<li>Hannes Breytenbach</li>
-			<li>Hugo Buddelmeijer</li>
-			<li>Doug Burke</li>
-			<li>Giorgio Calderone</li>
-			<li>Mihai Cara</li>
-			<li>Patti Carroll</li>
-			<li>Mabry Cervin</li>
-			<li>Pritish Chakraborty</li>
-			<li>Sourabh Cheedella</li>
-			<li>Alex Conley</li>
-			<li>Jean Connelly</li>
-			<li>Simon Conseil</li>
-			<li>Ryan Cooke</li>
-			<li>Yannick Copin</li>
-			<li>Michele Costa</li>
-			<li>Matthew Craig</li>
-			<li>Steve Crawford</li>
-			<li>Devin Crichton</li>
-			<li>Neil Crighton</li>
-			<li>Robert Cross</li>
-			<li>Kelle Cruz</li>
-			<li>Dan P. Cunningham</li>
-			<li>Ritwick DSouza</li>
-			<li>Daniel Datsev</li>
-			<li>Matt Davis</li>
-			<li>James Dearman</li>
-			<li>Christoph Deil</li>
-			<li>Nadia Dencheva</li>
-			<li>Eric Depagne</li>
-			<li>Jörg Dietrich</li>
-			<li>Axel Donath</li>
-			<li>Bili Dong</li>
-			<li>Michael Droettboom</li>
-			<li>Zach Edwards</li>
-			<li>Jonathan Eisenhamer</li>
-			<li>Thomas Erben</li>
-			<li>Henry Ferguson</li>
-			<li>Leonardo Ferreira</li>
-			<li>Tyler Finethy</li>
-			<li>Jonathan Foster</li>
-			<li>Ryan Fox</li>
-			<li>Lehman Garrison</li>
-			<li>Simon Gibbons</li>
-			<li>Adam Ginsburg</li>
-			<li>Christoph Gohlke</li>
-			<li>Danny Goldstein</li>
-			<li>Ralf Gommers</li>
-			<li>J. Goutin</li>
-			<li>Johnny Greco</li>
-			<li>Perry Greenfield</li>
-			<li>Dylan Gregersen</li>
-			<li>Austen Groener</li>
-			<li>Frédéric Grollier</li>
-			<li>Karan Grover</li>
-			<li>Kevin Gullikson</li>
-			<li>Hans Moritz Günther</li>
-			<li>Chris Hanley</li>
-			<li>Alex Hagen</li>
-			<li>Andrew Hearin</li>
-			<li>Christian Hettlage</li>
-			<li>Paul Hirst</li>
-			<li>Moataz Hisham</li>
-			<li>Michael Hoenig</li>
-			<li>Emma Hogan</li>
-			<li>Derek Homeier</li>
-			<li>Anthony Horton</li>
-			<li>JC Hsu</li>
-			<li>Griffin Hosseinzadeh</li>
-			<li>Lingyi Hu</li>
-			<li>Jurien Huisman</li>
-			<li>Joe Hunkeler</li>
-			<li>Anchit Jain</li>
-			<li>VSN Reddy Janga</li>
-			<li>Eric Jeschke</li>
-			<li>Graham Kanarek</li>
-			<li>Anirudh Katipally</li>
-			<li>Sarah Kendrew</li>
-			<li>Marten van Kerkwijk</li>
-			<li>Nicholas S. Kern</li>
-			<li>Wolfgang Kerzendorf</li>
-			<li>Lennard Kiehl</li>
-			<li>Rashid Khan</li>
-			<li>Aleh Khvalko</li>
-			<li>David Kirkby</li>
-			<li>Dominik Klaes</li>
-			<li>Tom Kooij</li>
-			<li>Kacper Kowalik</li>
-			<li>Roban Hultman Kramer</li>
-			<li>Aniket Kulkarni</li>
-			<li>Amit Kumar</li>
-			<li>Arie Kurniawan</li>
-			<li>Arne de Laat</li>
-			<li>Antony Lee</li>
-			<li>Daniel Lenz</li>
-			<li>Kieran Leschinski</li>
-			<li>Simon Liedtke</li>
-			<li>Pey Lian Lim</li>
-			<li>Stuart Littlefair</li>
-			<li>Joseph Long</li>
-			<li>Joe Lyman</li>
-			<li>Jerry Ma</li>
-			<li>Duncan Macleod</li>
-			<li>Michele Mastropietro</li>
-			<li>Curtis McCully</li>
-			<li>Vinayak Mehta</li>
-			<li>Aaron Meisner</li>
-			<li>Mikhail Minin</li>
-			<li>Serge Montagnac</li>
-			<li>José Sabater Montes</li>
-			<li>Francesco Montesano</li>
-			<li>Brett Morris</li>
-			<li>Michael Mueller</li>
-			<li>Stuart Mumford</li>
-			<li>Demitri Muna</li>
-			<li>Nick Murphy</li>
-			<li>Prasanth Nair</li>
-			<li>Stefan Nelson</li>
-			<li>Giang Nguyen</li>
-			<li>Bogdan Nicula</li>
-			<li>Al Niessner</li>
-			<li>Joe Philip Ninan</li>
-			<li>Asra Nizami</li>
-			<li>Bryce Nordgren</li>
-			<li>Sigurd Næss</li>
-			<li>Maximilian Nöthe</li>
-			<li>Sara Ogaz</li>
-			<li>Georgiana Ogrean</li>
-			<li>Semyeong Oh</li>
-			<li>Miruna Oprescu</li>
-			<li>Carl Osterwisch</li>
-			<li>Luigi Paioro</li>
-			<li>David M. Palmer</li>
-			<li>Asish Panda</li>
-			<li>John Parejko</li>
-			<li>Madhura Parikh</li>
-			<li>Neil Parley</li>
-			<li>Sergio Pascual</li>
-			<li>Pratik Patel</li>
-			<li>Rohit Patil</li>
-			<li>Aarya Patil</li>
-			<li>Ray Plante</li>
-			<li>Adele Plunkett</li>
-			<li>Orion Poplawski</li>
-			<li>Joanna Power</li>
-			<li>Adrian Price-Whelan</li>
-			<li>J. Xavier Prochaska</li>
-			<li>David Pérez-Suárez</li>
-			<li>Tanuj Rastogi</li>
-			<li>Thomas Robitaille</li>
-			<li>Juan Luis Cano Rodríguez</li>
-			<li>Evert Rol</li>
-			<li>Alex Rudy</li>
-			<li>Joseph Ryan</li>
-			<li>Eloy Salinas</li>
-			<li>Gerrit Schellenberger</li>
-			<li>Michael Seifert</li>
-			<li>Srikrishna Sekhar</li>
-			<li>Mathieu Servillat</li>
-			<li>Helen Sherwood-Taylor</li>
-			<li>David Shiga</li>
-			<li>Albert Y. Shih</li>
-			<li>David Shupe</li>
-			<li>Jonathan Sick</li>
-			<li>Max Silbiger</li>
-			<li>Bernie Simon</li>
-			<li>Sudheesh Singanamalla</li>
-			<li>Leo Singer</li>
-			<li>Brigitta Sipocz</li>
-			<li>Paul Sladen</li>
-			<li>Kevin Sooley</li>
-			<li>Shivan Sornarajah</li>
-			<li>Shantanu Srivastava</li>
-			<li>Ole Streicher</li>
-			<li>Matej Stuchlik</li>
-			<li>Bernardo Sulzbach</li>
-			<li>Vatsala Swaroop</li>
-			<li>Esteban Pardo Sánchez</li>
-			<li>James Taylor</li>
-			<li>Jeff Taylor</li>
-			<li>Mark Taylor</li>
-			<li>Kirill Tchernyshyov</li>
-			<li>Régis Terrier</li>
-			<li>Víctor Terrón</li>
-			<li>Scott Thomas</li>
-			<li>Erik Tollerud</li>
-			<li>Matthew Turk</li>
-			<li>James Turner</li>
-			<li>Miguel de Val-Borro</li>
-			<li>Jake VanderPlas</li>
-			<li>Alex de la Vega</li>
-			<li>Sam Verstocken</li>
-			<li>Zé Vinicius</li>
-			<li>Karl Vyhmeister</li>
-			<li>Lisa Walter</li>
-			<li>Laura Watkins</li>
-			<li>Benjamin Alan Weaver</li>
-			<li>Jonathan Whitmore</li>
-			<li>Julien Woillez</li>
-			<li>Maneesh Yadav</li>
-			<li>Víctor Zabalza</li>
+            <li> Ryan Abernathey</li>
+            <li> Mohan Agrawal</li>
+            <li> Shailesh Ahuja</li>
+            <li> Tom Aldcroft</li>
+            <li> Anne Archibald</li>
+            <li> Cristian Ardelean</li>
+            <li> Tomas Babej</li>
+            <li> Matteo Bachetti</li>
+            <li> Alexander Bakanov</li>
+            <li> Steven Bamford</li>
+            <li> Kyle Barbary</li>
+            <li> Geert Barentsen</li>
+            <li> Pauline Barmby</li>
+            <li> Paul Barrett</li>
+            <li> Andreas Baumbach</li>
+            <li> Chris Beaumont</li>
+            <li> Stefan Becker</li>
+            <li> Daniel Bell</li>
+            <li> Elijah Bernstein-Cooper</li>
+            <li> Kristin Berry</li>
+            <li> Edward Betts</li>
+            <li> Mavani Bhautik</li>
+            <li> Nimit Bhardwaj</li>
+            <li> Mavani Bhautik</li>
+            <li> Francesco Biscani</li>
+            <li> Thompson Le Blanc</li>
+            <li> Christopher Bonnett</li>
+            <li> Joseph Jon Booker</li>
+            <li> Médéric Boquien</li>
+            <li> Azalee Bostroem</li>
+            <li> Luke G. Bouma</li>
+            <li> Matthew Bourque</li>
+            <li> Larry Bradley</li>
+            <li> Gustavo Bragança</li>
+            <li> Gabriel Brammer</li>
+            <li> Erik M. Bray</li>
+            <li> Eli Bressert</li>
+            <li> Matthew Brett</li>
+            <li> Hannes Breytenbach</li>
+            <li> Hugo Buddelmeijer</li>
+            <li> Doug Burke</li>
+            <li> Giorgio Calderone</li>
+            <li> Mihai Cara</li>
+            <li> Patti Carroll</li>
+            <li> Mabry Cervin</li>
+            <li> Pritish Chakraborty</li>
+            <li> Sourabh Cheedella</li>
+            <li> Alex Conley</li>
+            <li> Jean Connelly</li>
+            <li> Simon Conseil</li>
+            <li> Ryan Cooke</li>
+            <li> Yannick Copin</li>
+            <li> Michele Costa</li>
+            <li> Matthew Craig</li>
+            <li> Steve Crawford</li>
+            <li> Devin Crichton</li>
+            <li> Neil Crighton</li>
+            <li> Robert Cross</li>
+            <li> Kelle Cruz</li>
+            <li> Dan P. Cunningham</li>
+            <li> Daniel D'Avella</li>
+            <li> Ritwick DSouza</li>
+            <li> Daniel Datsev</li>
+            <li> Matt Davis</li>
+            <li> James Dearman</li>
+            <li> Christoph Deil</li>
+            <li> Nadia Dencheva</li>
+            <li> Eric Depagne</li>
+            <li> Akash Deshpande</li>
+            <li> Jörg Dietrich</li>
+            <li> Axel Donath</li>
+            <li> Bili Dong</li>
+            <li> Michael Droettboom</li>
+            <li> Zach Edwards</li>
+            <li> Jonathan Eisenhamer</li>
+            <li> Thomas Erben</li>
+            <li> Henry Ferguson</li>
+            <li> Leonardo Ferreira</li>
+            <li> Tyler Finethy</li>
+            <li> Jonathan Foster</li>
+            <li> Ryan Fox</li>
+            <li> Lehman Garrison</li>
+            <li> Simon Gibbons</li>
+            <li> Adam Ginsburg</li>
+            <li> Christoph Gohlke</li>
+            <li> Danny Goldstein</li>
+            <li> Ralf Gommers</li>
+            <li> Karl Gordon</li>
+            <li> J. Goutin</li>
+            <li> Johnny Greco</li>
+            <li> Perry Greenfield</li>
+            <li> Dylan Gregersen</li>
+            <li> Austen Groener</li>
+            <li> Frédéric Grollier</li>
+            <li> Karan Grover</li>
+            <li> Kevin Gullikson</li>
+            <li> Hans Moritz Günther</li>
+            <li> Chris Hanley</li>
+            <li> Alex Hagen</li>
+            <li> Andrew Hearin</li>
+            <li> Christian Hettlage</li>
+            <li> Paul Hirst</li>
+            <li> Moataz Hisham</li>
+            <li> Michael Hoenig</li>
+            <li> Emma Hogan</li>
+            <li> Derek Homeier</li>
+            <li> Anthony Horton</li>
+            <li> JC Hsu</li>
+            <li> Griffin Hosseinzadeh</li>
+            <li> Lingyi Hu</li>
+            <li> Jurien Huisman</li>
+            <li> Joe Hunkeler</li>
+            <li> Zeljko Ivezic</li>
+            <li> Anchit Jain</li>
+            <li> Anany Shrey Jain</li>
+            <li> VSN Reddy Janga</li>
+            <li> Eric Jeschke</li>
+            <li> Graham Kanarek</li>
+            <li> Anirudh Katipally</li>
+            <li> Sarah Kendrew</li>
+            <li> Marten van Kerkwijk</li>
+            <li> Nicholas S. Kern</li>
+            <li> Wolfgang Kerzendorf</li>
+            <li> Lennard Kiehl</li>
+            <li> Rashid Khan</li>
+            <li> Aleh Khvalko</li>
+            <li> David Kirkby</li>
+            <li> Dominik Klaes</li>
+            <li> Tom Kooij</li>
+            <li> Kacper Kowalik</li>
+            <li> Roban Hultman Kramer</li>
+            <li> Aniket Kulkarni</li>
+            <li> Amit Kumar</li>
+            <li> Arie Kurniawan</li>
+            <li> Arne de Laat</li>
+            <li> Antony Lee</li>
+            <li> Daniel Lenz</li>
+            <li> Kieran Leschinski</li>
+            <li> Simon Liedtke</li>
+            <li> Pey Lian Lim</li>
+            <li> Stuart Littlefair</li>
+            <li> Joseph Long</li>
+            <li> Joe Lyman</li>
+            <li> Jerry Ma</li>
+            <li> Duncan Macleod</li>
+            <li> Michele Mastropietro</li>
+            <li> Jeffrey McBeth</li>
+            <li> Mike McCarty</li>
+            <li> Curtis McCully</li>
+            <li> Vinayak Mehta</li>
+            <li> Aaron Meisner</li>
+            <li> Mikhail Minin</li>
+            <li> Serge Montagnac</li>
+            <li> José Sabater Montes</li>
+            <li> Francesco Montesano</li>
+            <li> Brett Morris</li>
+            <li> Michael Mueller</li>
+            <li> Stuart Mumford</li>
+            <li> Demitri Muna</li>
+            <li> Nick Murphy</li>
+            <li> Prasanth Nair</li>
+            <li> Stefan Nelson</li>
+            <li> Giang Nguyen</li>
+            <li> Bogdan Nicula</li>
+            <li> Al Niessner</li>
+            <li> Joe Philip Ninan</li>
+            <li> Asra Nizami</li>
+            <li> Bryce Nordgren</li>
+            <li> Sigurd Næss</li>
+            <li> Maximilian Nöthe</li>
+            <li> Ricardo Ogando</li>
+            <li> Sara Ogaz</li>
+            <li> Georgiana Ogrean</li>
+            <li> Semyeong Oh</li>
+            <li> Bruno Oliveira</li>
+            <li> K.A. Oman</li>
+            <li> Miruna Oprescu</li>
+            <li> Carl Osterwisch</li>
+            <li> Luigi Paioro</li>
+            <li> David M. Palmer</li>
+            <li> Asish Panda</li>
+            <li> John Parejko</li>
+            <li> Madhura Parikh</li>
+            <li> Neil Parley</li>
+            <li> Sergio Pascual</li>
+            <li> Pratik Patel</li>
+            <li> Aarya Patil</li>
+            <li> Rohit Patil</li>
+            <li> Sushobhana Patra</li>
+            <li> Molly Peeples</li>
+            <li> Ray Plante</li>
+            <li> Adele Plunkett</li>
+            <li> Orion Poplawski</li>
+            <li> Joanna Power</li>
+            <li> Paul Price</li>
+            <li> Adrian Price-Whelan</li>
+            <li> J. Xavier Prochaska</li>
+            <li> David Pérez-Suárez</li>
+            <li> Tanuj Rastogi</li>
+            <li> Thomas Robitaille</li>
+            <li> Juan Luis Cano Rodríguez</li>
+            <li> Evert Rol</li>
+            <li> Alex Rudy</li>
+            <li> Joseph Ryan</li>
+            <li> Saurav Sachidanand</li>
+            <li> Eloy Salinas</li>
+            <li> Gerrit Schellenberger</li>
+            <li> Michael Seifert</li>
+            <li> Srikrishna Sekhar</li>
+            <li> Mathieu Servillat</li>
+            <li> Helen Sherwood-Taylor</li>
+            <li> David Shiga</li>
+            <li> Albert Y. Shih</li>
+            <li> David Shupe</li>
+            <li> Jonathan Sick</li>
+            <li> Max Silbiger</li>
+            <li> Bernie Simon</li>
+            <li> Sudheesh Singanamalla</li>
+            <li> Leo Singer</li>
+            <li> Brigitta Sipocz</li>
+            <li> Paul Sladen</li>
+            <li> Kevin Sooley</li>
+            <li> Shivan Sornarajah</li>
+            <li> Megan Sosey</li>
+            <li> Shantanu Srivastava</li>
+            <li> David Stansby</li>
+            <li> Ole Streicher</li>
+            <li> Matej Stuchlik</li>
+            <li> Bernardo Sulzbach</li>
+            <li> Jonas Große Sundrup</li>
+            <li> Vatsala Swaroop</li>
+            <li> Esteban Pardo Sánchez</li>
+            <li> James Taylor</li>
+            <li> Jeff Taylor</li>
+            <li> Mark Taylor</li>
+            <li> Kirill Tchernyshyov</li>
+            <li> Régis Terrier</li>
+            <li> Víctor Terrón</li>
+            <li> Peter Teuben</li>
+            <li> Scott Thomas</li>
+            <li> Erik Tollerud</li>
+            <li> Matthew Turk</li>
+            <li> James Turner</li>
+            <li> Miguel de Val-Borro</li>
+            <li> Jake VanderPlas</li>
+            <li> Alex de la Vega</li>
+            <li> Shresth Verma</li>
+            <li> Sam Verstocken</li>
+            <li> Zé Vinicius</li>
+            <li> Karl Vyhmeister</li>
+            <li> Lisa Walter</li>
+            <li> Laura Watkins</li>
+            <li> Benjamin Alan Weaver</li>
+            <li> Jonathan Whitmore</li>
+            <li> Julien Woillez</li>
+            <li> Michael Wood-Vasey</li>
+            <li> Maneesh Yadav</li>
+            <li> Víctor Zabalza</li>
 		</ul>
 
 		<h3>Other Credits</h3>


### PR DESCRIPTION
This PR adds text for the release announcement for Astropy v3.0.

One thing to note: The "cite this" part is slightly awkward given paper ii is not yet in the journal.  I basically adopted @bsipocz's approach from astropy/astropy#7158, although modified to fit the html.  There is an open question whether we should update the web site's citation text (http://www.astropy.org/acknowledging.html) to *also* say this.  I'm inclined to wait on that until the paper is actually in the journal.  If we agree on this I'll just make a WIP PR to do that separate from this one.  Any opinions on this, @adrn, @crawfordsm, @hamogu, or @bsipocz?