### PR TITLE
Remove old doc links. Add 2.0.4 doc link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,14 +51,8 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v2.0.4/index.html" target="_blank">v2.0.4</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.3.3/index.html" target="_blank">v1.3.3</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/v1.2.2/index.html" target="_blank">v1.2.2</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/v1.1.2/index.html" target="_blank">v1.1.2</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/v1.0.13/index.html" target="_blank">v1.0.13</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/v0.4.6/index.html" target="_blank">v0.4.6</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/v0.3.2/index.html" target="_blank">v0.3.2</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/v0.2.5/index.html" target="_blank">v0.2.5</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/v0.1/index.html" target="_blank">v0.1</a></li>
 							</ul>
 						</div>
 					</div>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v2.0.4/index.html" target="_blank">v2.0.4</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.3.3/index.html" target="_blank">v1.3.3</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/v1.0.13/index.html" target="_blank">v1.0.13</a></li>
 							</ul>
 						</div>
 					</div>


### PR DESCRIPTION
Fix #186.

This is a quick fix until doc overhaul mentioned in https://github.com/astropy/astropy.github.com/issues/186#issuecomment-363866777 .

Original motivation: I was looking for 2.x doc and couldn't find it, so I went to this drop-down menu and couldn't find it either.