### PR TITLE
Updating spherical geometry maintainer in registry

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -293,7 +293,7 @@
         },
         {
             "name": "spherical_geometry",
-            "maintainer": "Bernie Simon and Michael Droettboom",
+            "maintainer": "Bernie Simon",
             "provisional": "2015-12-26",
             "stable": false,
             "home_url": "https://spacetelescope.github.io/spherical_geometry/spherical_geometry/",


### PR DESCRIPTION
This came up while updating the table for the astropy paper. 