### PR TITLE
A new design for the Affiliated Packages Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.py[co]
+*.DS_STORE

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="shortcut icon" href="../favicon.ico" />
 
-<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css' />
+<link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700" rel="stylesheet" type="text/css" />
 <link rel="stylesheet" type="text/css" href="../css/style.css" />
 <link rel="stylesheet" type="text/css" href="../css/jquery.sidr.light.css" />
 
@@ -79,12 +79,41 @@
 	</section>
 
 	<section id="affiliated-package-registry">
-
-	<h1>Affiliated Packages Registry</h1>
-
-	<p>The following tables list all currently registered affiliated packages. They are determined from the <a href="http://www.astropy.org/affiliated/registry.json">json file</a>, which is the actual authoritative registry. The Stable column indicates whether the package maintainer consider the package to be ready for use. Packages that are under heavy development and for which the user interface is likely to change significantly in the near future are marked as No.</p>
-
-	<h3><u>Affiliated Packages</u></h3>
+	  <h1>Affiliated Packages Registry</h1>
+	  <p>The following table lists all currently registered affiliated packages. They are determined from the <a href="http://www.astropy.org/affiliated/registry.json">json file</a>, which is the actual authoritative registry.</p>
+<!--	  <h3><u>Affiliated Packages</u></h3>-->
+		
+		
+	<table border="1" class="docutils" id="accepted-package-table">
+	<colgroup>
+	<col width="5%" />
+	<col width="3%" />
+	<col width="3%" />
+	<col width="10%" />
+	</colgroup>
+	<thead valign="bottom">
+	<tr class="row-odd">
+	<th class="head"></th>
+	<th class="head"></th>
+	<th class="head"></th>
+	<th class="head"></th>
+	</tr>
+	</thead>
+	<tbody valign="top">
+	<tr class="row-even"><td rowspan="1">Loading...</td>
+	<td rowspan="1">&nbsp;</td>
+	<td rowspan="1">&nbsp;</td>
+	<td rowspan="1">&nbsp;</td>
+	<td rowspan="1">&nbsp;</td>
+	</tr>
+	<tr class="row-odd">	
+	<td colspan="1">&nbsp;</td>
+	<td colspan="3">&nbsp;</td>
+	</tr>
+	</tbody>
+	</table>
+		
+<!--
 	<table border="1" class="docutils" id="accepted-package-table">
 	<colgroup>
 	<col width="17%" />
@@ -95,12 +124,12 @@
 	<col width="14%" />
 	</colgroup>
 	<thead valign="bottom">
-	<tr class="row-odd"><th class="head">Package Name</th>
-	<th class="head">Stable</th>
-	<th class="head">PyPI Name</th>
-	<th class="head">Web Page</th>
-	<th class="head">Code Repository</th>
-	<th class="head">Maintainer</th>
+	<tr class="row-odd"><th class="head"></th>
+	<th class="head"></th>
+	<th class="head"></th>
+	<th class="head"></th>
+	<th class="head"></th>
+	<th class="head"></th>
 	</tr>
 	</thead>
 	<tbody valign="top">
@@ -115,6 +144,7 @@
 	<tr class="row-odd"></tr>
 	</tbody>
 	</table>
+-->
 
 	<h3><u>Other astronomy packages</u></h3>
 

--- a/css/style.css
+++ b/css/style.css
@@ -577,7 +577,7 @@ td:first-child {
   }
 
 /* Create gray border after every 3rd row to visually separate packages */
-table tr:nth-of-type(3n) td {
+table tr:nth-of-type(4n) td {
     border-bottom: 1px solid rgba(128,128,128,0.2);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -561,7 +561,7 @@ thead{
 
 
 td{
-	padding:16px 5px;
+	padding:12px 5px;
 	font-size: 100%;
 	line-height: 1.3em;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -550,11 +550,6 @@ table{
 	word-break:overflow-wrap;
 }
 
-/*
-tr{
-	border-bottom: 1px #efefef solid;
-}
-*/
 
 
 thead{
@@ -567,7 +562,7 @@ thead{
 
 td{
 	padding:16px 5px;
-	font-size: 140%;
+	font-size: 100%;
 	line-height: 1.3em;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -560,7 +560,7 @@ tr{
 thead{
 	text-align: left;
 	font-weight: bold;
-	border-bottom: 1px black solid;
+	border-bottom: 1px solid rgba(128,128,128,0.2);
 }
 
 
@@ -575,6 +575,11 @@ td{
 td:first-child {
     font-weight: bold;
   }
+
+/* Create gray border after every 3rd row to visually separate packages */
+table tr:nth-of-type(3n) td {
+    border-bottom: 1px solid rgba(128,128,128,0.2);
+}
 
 
 /* About */

--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,7 @@ time, mark, audio, video {
 	font: inherit;
 	vertical-align: baseline;
 }
+
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
@@ -540,18 +541,20 @@ section.install div h3{
 }
 
 .featured img{
-	float: left;
+	float: left+;
 	margin-right:10px;
 }
 
 table{
 	margin: 20px 0px;
-	word-break:break-all;
+	word-break:overflow-wrap;
 }
 
+/*
 tr{
 	border-bottom: 1px #efefef solid;
 }
+*/
 
 
 thead{
@@ -560,9 +563,19 @@ thead{
 	border-bottom: 1px black solid;
 }
 
+
+
 td{
-	padding:5px 3px;
+	padding:16px 5px;
+	font-size: 140%;
+	line-height: 1.3em;
 }
+
+
+td:first-child {
+    font-weight: bold;
+  }
+
 
 /* About */
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -357,10 +357,10 @@ var review_name_map = {"functionality": "Functionality",
     "python3": "Python 3"
 };
 
-var review_default_color = "green";
+var review_default_color = "brightgreen";
 var review_color_map = {'Unmaintained': "red",
     "Functional but low activity": "orange",
-    "Good": "green",
+    "Good": "brightgreen",
     "Partial": "orange",
     "Needs work": "red"
 };


### PR DESCRIPTION
Partially in the spirit of astropy/astropy-APES#40, @eteq (LONG ago) proposed an overhaul / refresh of the Affiliated Packages table. 

Following on #pyastro18's recent Hack Day, @eteq, @astrofrog and myself propose the following design. Note that this specific design is entirely the brainchild of @astrofrog, and @eteq did most of the actual implementation. 

<img width="1003" alt="screen shot 2018-05-07 at 11 02 07 am" src="https://user-images.githubusercontent.com/2238418/39713228-0bc90a64-51f4-11e8-9242-816436ca8462.png">


This new table aims to simultaneously increase per-package information density while also improving readability. Miraculously, I think it does both (thanks entirely to @astrofrog and @eteq's great ideas). 

This table, of course, dynamically pulls from the JSON registry, and can be easily adapted to any forthcoming evolution of the Astropy affiliated package model. 


Edit: You can see a live preview of this change [here](http://hea-www.cfa.harvard.edu/~tremblay/Astropy_Preview/preview/affiliated/index.html).