### PR TITLE
Improve instructions for installing affiliated packages

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -64,7 +64,7 @@
 
 	<p>A major part of the Astropy Project is the concept of “Affiliated Packages”. An affiliated package is an astronomy-related Python package that is not part of the astropy core package, but has requested to be included as part of the Astropy Project community. These packages demonstrate a commitment to Astropy’s goals of improving reuse, interoperability, and interface standards for Python astronomy and astrophysics packages.</p>
 
-	<p>If you are developer interested in signing up as an affiliated package, details are at the <a href="#affiliated-instructions">end of this page.</a></p>
+	<p>If you are developer interested in signing up as an affiliated package, details are in the <a href="#affiliated-instructions">Becoming an Affiliated Package</a> section.</p>
 
 	</section>
 
@@ -72,9 +72,9 @@
 
 	<h1>Installing Affiliated Packages</h1>
 
-	<p>  The simplest way to install and keep up-to-date most affiliated packages is to use the <a href="https://www.continuum.io/why-anaconda">Anaconda python distribution</a>.  This distribution provides Astropy built-in, and affiliated packages are available from a  "channel" <a href="https://github.com/astropy/conda-channel-astropy">maintained by the Astropy community</a>.  You can see  the affiliated packages in the channel <a href="https://anaconda.org/astropy/packages">here</a>, and if you have anaconda installed, you can do <code>conda search -c astropy some_affiliated_package</code>.  Most importantly, you can then install them with <code>conda install -c astropy some_affiliated_package</code>. </p>
+	<p>  The simplest way to install and keep up-to-date most affiliated packages is to use the <a href="https://www.continuum.io/why-anaconda">Anaconda python distribution</a>.  This distribution includes the <a href="http://astropy.readthedocs.io/en/stable/index.html">Astropy core package</a> already built in, and you can then easily install or update affiliated packages using the <a href="https://anaconda.org/astropy/packages">Astropy Conda channel</a> of binary installable packages.  Once you have Anaconda installed, you can do <code>conda search --channel astropy some_affiliated_package</code>.  Most importantly, you can then install them with <code>conda install --channel astropy some_affiliated_package</code>.  The Astropy channel is maintained by the Astropy Project on Github via code in the <a href="https://github.com/astropy/conda-channel-astropy">conda-channel-astropy</a> repository. </p>
 
-	<p> If you do not have Anaconda or wish to install from source, for most affiliated packages, downloading the source code and doing <code>python setup.py install</code> will work.  Many also support the Astropy core package's additional build and install options, as they use the affiliated package template (detailed more <a href="#affiliated-instructions">below</a>). That said, affiliated packages are developed independently of the Astropy core library.  This means they are free to develop their packages as they see fit, and can have a variety of different requirements or  unusual install procedures.  Hence you should refer to the package's documentation first if you encounter problems.</p>
+	<p> If you do not have Anaconda or wish to install from source, for most affiliated packages, downloading the source code and doing <code>python setup.py install</code> will work.  Many also support the Astropy core package's additional build and install options, as they use the affiliated package template (detailed more in the <a href="#affiliated-instructions">Becoming an Affiliated Package</a> section). That said, affiliated packages are developed independently of the Astropy core library.  This means they are free to develop their packages as they see fit, and can have a variety of different requirements or  unusual install procedures.  Hence you should refer to the package's documentation first if you encounter problems.</p>
 
 	</section>
 


### PR DESCRIPTION
This reworks the section on installing affiliated packages to be a bit more direct for users.  For instance the first Astropy Conda channel link they encounter is the actual channel, not the Github repo.

It also replaces href tags like "here" or "end of this page" or "below" with more descriptive text.