### PR TITLE
Simplify citation information on acknowledgements page

### DIFF
--- a/about.html
+++ b/about.html
@@ -39,7 +39,7 @@
                     <ul>
                     <li><a href="about.html">About Astropy</a></li>
                     <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="acknowledging.html">Acknowledging</a></li>
+                    <li><a href="acknowledging.html">Acknowledging & Citing</a></li>
                     </ul>
                   </div>
                 </div>

--- a/acknowledging.html
+++ b/acknowledging.html
@@ -39,7 +39,7 @@
                     <ul>
                     <li><a href="about.html">About Astropy</a></li>
                     <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="acknowledging.html">Acknowledging</a></li>
+                    <li><a href="acknowledging.html">Acknowledging & Citing</a></li>
                     </ul>
                   </div>
                 </div>

--- a/acknowledging.html
+++ b/acknowledging.html
@@ -18,6 +18,51 @@
 
 <!-- Google analytics -->
 <script src="js/analytics.js"></script>
+
+<script type="text/javascript">
+    function copyBibtex() {
+        var bibtex2013 = `@article{astropy:2013,
+Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+Adsurl = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A},
+Archiveprefix = {arXiv},
+Author = {{Astropy Collaboration} and {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Greenfield}, P. and {Droettboom}, M. and {Bray}, E. and {Aldcroft}, T. and {Davis}, M. and {Ginsburg}, A. and {Price-Whelan}, A.~M. and {Kerzendorf}, W.~E. and {Conley}, A. and {Crighton}, N. and {Barbary}, K. and {Muna}, D. and {Ferguson}, H. and {Grollier}, F. and {Parikh}, M.~M. and {Nair}, P.~H. and {Unther}, H.~M. and {Deil}, C. and {Woillez}, J. and {Conseil}, S. and {Kramer}, R. and {Turner}, J.~E.~H. and {Singer}, L. and {Fox}, R. and {Weaver}, B.~A. and {Zabalza}, V. and {Edwards}, Z.~I. and {Azalee Bostroem}, K. and {Burke}, D.~J. and {Casey}, A.~R. and {Crawford}, S.~M. and {Dencheva}, N. and {Ely}, J. and {Jenness}, T. and {Labrie}, K. and {Lim}, P.~L. and {Pierfederici}, F. and {Pontzen}, A. and {Ptak}, A. and {Refsdal}, B. and {Servillat}, M. and {Streicher}, O.},
+Doi = {10.1051/0004-6361/201322068},
+Eid = {A33},
+Eprint = {1307.6212},
+Journal = {\aap},
+Keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
+Month = oct,
+Pages = {A33},
+Primaryclass = {astro-ph.IM},
+Title = {{Astropy: A community Python package for astronomy}},
+Volume = 558,
+Year = 2013,
+Bdsk-Url-1 = {https://dx.doi.org/10.1051/0004-6361/201322068}}`;
+
+        var bibtex2018 = `@article{astropy:2018,
+Adsnote = {Provided by the SAO/NASA Astrophysics Data System},
+Adsurl = {https://ui.adsabs.harvard.edu/#abs/2018AJ....156..123T},
+Author = {{Price-Whelan}, A.~M. and {Sip{\'{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L. and {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and {VanderPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-Su{\'a}rez}, D. and {de Val-Borro}, M. and {Paper Contributors}, (Primary and {Aldcroft}, T.~L. and {Cruz}, K.~L. and {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Coordination Committee}, (Astropy and {Ardelean}, C. and {Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and {Bostroem}, K.~A. and {Bouma}, L.~G. and {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and {Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\'\i}guez}, J.~L. and {Cara}, M. and {Cardoso}, J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and {Corrales}, L. and {Crichton}, D. and {D{\textquoteright}Avella}, D. and {Deil}, C. and {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern}, N.~S. and {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J. and {Kirkby}, D. and {Kulkarni}, A.~M. and {Kumar}, A. and {Lee}, A. and {Lenz}, D. and {Littlefair}, S.~P. and {Ma}, Z. and {Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C. and {Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and {Muna}, D. and {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and {Sakurikar}, P. and {Seifert}, M. and {Sherbert}, L.~E. and {Sherwood-Taylor}, H. and {Shih}, A.~Y. and {Sick}, J. and {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and {Zabalza}, V. and {Contributors}, (Astropy},
+Doi = {10.3847/1538-3881/aabc4f},
+Eid = {123},
+Journal = {\aj},
+Keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
+Month = Sep,
+Pages = {123},
+Primaryclass = {astro-ph.IM},
+Title = {{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}},
+Volume = {156},
+Year = 2018,
+Bdsk-Url-1 = {https://doi.org/10.3847/1538-3881/aabc4f}}`;
+
+        var $temp = $("<textarea>");
+        $("body").append($temp);
+        $temp.val(bibtex2013 + '\r\n\r\n' + bibtex2018).select();
+        document.execCommand("copy");
+        $temp.remove();
+    }
+</script>
+
 </head>
 
 <body>
@@ -65,21 +110,35 @@
 
 		<h1>Acknowledging or Citing Astropy</h1>
 
-		<h3>In Publications</h3>
+		<h2>In Publications</h2>
 
-		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you cite the <a href="https://arxiv.org/abs/1801.02634" target="_blank">Astropy Paper II</a> (<a href="http://adsabs.harvard.edu/abs/2018arXiv180102634T" target="_blank">ADS</a> -
-		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180102634T&data_type=BIBTEX&db_key=PRE&nocookieset=1" target="_blank">BibTeX</a>).</p>
-        We provide the following as a standard  acknowledgment you can use if there is not a specific place to cite the paper:</p>
+		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you please cite the Astropy papers:
+            <ul>
+                <li><a href="https://arxiv.org/abs/1801.02634" target="_blank">Astropy Paper II</a>
+                    (<a href="http://adsabs.harvard.edu/abs/2018arXiv180102634T" target="_blank">ADS</a> -
+                    <a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180102634T&data_type=BIBTEX&db_key=PRE&nocookieset=1" target="_blank">BibTeX</a>)
+                </li>
+                <li><a href="https://doi.org/10.1051/0004-6361/201322068" target="_blank">Astropy Paper I</a>
+                    (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
+                    <a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>)
+                </li>
+            </ul>
+    </p>
 
-		<p class="citation"><cite>This research made use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2018).</cite></p>
+        <a class="button" onclick="copyBibtex()">Copy BibTeX to clipboard</a>
 
-        <p> This paper is still under review, however, and an earlier paper is available
-		describing the status of the package at the time of v0.2. If your work has 
-		used Astropy since then, you can instead cite <cite>(Astropy Collaboration, 2013, 2018)</cite>  where <cite>(Astropy Collaboration, 2013)</cite> is a citation to the <a href="https://doi.org/10.1051/0004-6361/201322068" target="_blank">first Astropy Paper</a> (<a href="http://adsabs.harvard.edu/abs/2013A%26A...558A..33A" target="_blank">ADS</a> -
-		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1" target="_blank">BibTeX</a>).</p>
-		<p>If you wish, you can also include a link to <cite>http://www.astropy.org</cite> (if the journal allows this) in addition to the above text.</p>
+        <p>
+            We provide the following LaTeX/BibTeX acknowledgment if there is no specific place to cite the papers:
+        </p>
 
-		<h3>In Presentations</h3>
+		<p class="citation">
+            <cite>This research made use of Astropy,\footnote{http://www.astropy.org} a community-developed core Python package for Astronomy \citep{astropy:2013, astropy:2018}.
+            </cite>
+        </p>
+
+        <hr style='margin: 24pt 0px 24pt 0px;'>
+
+		<h2>In Presentations</h2>
 
 		<p>If you are giving a presentation or talk featuring work/research that makes use of Astropy and would like to acknowledge Astropy, we suggest using this logo on your title slide:</p>
 
@@ -87,11 +146,11 @@
 
 		<p>The logo is also available <a href="http://www.astropy.org/images/astropy_powered_white.png">with white text</a>, or the SVG originals can be obtained at the <a href="http://github.com/astropy/astropy-logo" target="_blank">astropy-logo github repository.</a></p>
 
-		<h3>In Projects</h3>
+        <hr style='margin: 24pt 0px 24pt 0px;'>
+
+		<h2>In Projects</h2>
 
 		<p>If you are using Astropy as part of a code project (e.g., affiliated packages), a useful way to acknowledge your use of Astropy is with a badge in your README. We suggest this badge: </p>
-
-
 
 		<img src="http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat" alt="Powered by Astropy Badge"/>
 

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -36,7 +36,7 @@
                     <ul>
                     <li><a href="../about.html">About Astropy</a></li>
                     <li><a href="../code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="../acknowledging.html">Acknowledging</a></li>
+                    <li><a href="../acknowledging.html">Acknowledging & Citing</a></li>
                     </ul>
                   </div>
                 </div>
@@ -82,8 +82,8 @@
 	  <h1>Affiliated Packages Registry</h1>
 	  <p>The following table lists all currently registered affiliated packages. They are determined from the <a href="http://www.astropy.org/affiliated/registry.json">json file</a>, which is the actual authoritative registry.</p>
 <!--	  <h3><u>Affiliated Packages</u></h3>-->
-		
-		
+
+
 	<table border="1" class="docutils" id="accepted-package-table">
 	<colgroup>
 	<col width="5%" />
@@ -106,13 +106,13 @@
 	<td rowspan="1">&nbsp;</td>
 	<td rowspan="1">&nbsp;</td>
 	</tr>
-	<tr class="row-odd">	
+	<tr class="row-odd">
 	<td colspan="1">&nbsp;</td>
 	<td colspan="3">&nbsp;</td>
 	</tr>
 	</tbody>
 	</table>
-		
+
 <!--
 	<table border="1" class="docutils" id="accepted-package-table">
 	<colgroup>

--- a/announcements/release-2.0.html
+++ b/announcements/release-2.0.html
@@ -37,7 +37,7 @@
 							<ul>
 								<li><a href="../about.html">About Astropy</a></li>
 								<li><a href="../code_of_conduct.html">Code of Conduct</a></li>
-								<li><a href="../acknowledging.html">Acknowledging</a></li>
+								<li><a href="../acknowledging.html">Acknowledging & Citing</a></li>
 							</ul>
 						</div>
 					</div>
@@ -113,7 +113,7 @@
 		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="http://docs.astropy.org/en/stable/whatsnew/2.0.html">http://docs.astropy.org/en/stable/whatsnew/2.0.html</a>
 		</p>
 		<p>
-		Note that the Astropy 2.x series will be the last versions of Astropy that will support Python 2.x.  Future versions of Astropy will only support Python 3.x. 
+		Note that the Astropy 2.x series will be the last versions of Astropy that will support Python 2.x.  Future versions of Astropy will only support Python 3.x.
 		</p>
 		<p>
 		Instructions for installing Astropy are provided on our <a

--- a/announcements/release-3.0.html
+++ b/announcements/release-3.0.html
@@ -37,7 +37,7 @@
 							<ul>
 								<li><a href="../about.html">About Astropy</a></li>
 								<li><a href="../code_of_conduct.html">Code of Conduct</a></li>
-								<li><a href="../acknowledging.html">Acknowledging</a></li>
+								<li><a href="../acknowledging.html">Acknowledging & Citing</a></li>
 							</ul>
 						</div>
 					</div>
@@ -170,7 +170,7 @@ pip install astropy --upgrade
 		<a href="http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2018arXiv180102634T&data_type=BIBTEX&db_key=PRE&nocookieset=1" target="_blank">BibTeX</a>).</p>
 		<p>
 		This paper is still under review, however, and an earlier paper is available
-		describing the status of the package at the time of v0.2. If your work has 
+		describing the status of the package at the time of v0.2. If your work has
 		used Astropy since then, you are encouraged to acknowledge both papers:
 	  </p>
 

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -39,7 +39,7 @@
                     <ul>
                     <li><a href="about.html">About Astropy</a></li>
                     <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="acknowledging.html">Acknowledging</a></li>
+                    <li><a href="acknowledging.html">Acknowledging & Citing</a></li>
                     </ul>
                   </div>
                 </div>

--- a/contribute.html
+++ b/contribute.html
@@ -37,7 +37,7 @@
                     <ul>
                     <li><a href="about.html">About Astropy</a></li>
                     <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="acknowledging.html">Acknowledging</a></li>
+                    <li><a href="acknowledging.html">Acknowledging & Citing</a></li>
                     </ul>
                   </div>
                 </div>

--- a/help.html
+++ b/help.html
@@ -36,7 +36,7 @@
                     <ul>
                     <li><a href="about.html">About Astropy</a></li>
                     <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="acknowledging.html">Acknowledging</a></li>
+                    <li><a href="acknowledging.html">Acknowledging & Citing</a></li>
                     </ul>
                   </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 							<ul>
 								<li><a href="about.html">About Astropy</a></li>
 								<li><a href="code_of_conduct.html">Code of Conduct</a></li>
-								<li><a href="acknowledging.html">Acknowledging</a></li>
+								<li><a href="acknowledging.html">Acknowledging & Citing</a></li>
 							</ul>
 						</div>
 					</div>

--- a/team.html
+++ b/team.html
@@ -39,7 +39,7 @@
                     <ul>
                     <li><a href="about.html">About Astropy</a></li>
                     <li><a href="code_of_conduct.html">Code of Conduct</a></li>
-                    <li><a href="acknowledging.html">Acknowledging</a></li>
+                    <li><a href="acknowledging.html">Acknowledging & Citing</a></li>
                     </ul>
                   </div>
                 </div>


### PR DESCRIPTION
1. This changes "Acknowledging" to "Acknowledging & Citing" in the menu bar
2. I tried to simplify the suggested citation and text surrounding the topic, and added a button to copy the bibtex entries for both papers to the clipboard (similar to ADS)

This fixes #263 

cc @astrofrog @eteq 