### PR TITLE
Should the acknowledgement for Astropy say *both* papers or not?

### DIFF
--- a/acknowledging.html
+++ b/acknowledging.html
@@ -112,7 +112,7 @@ Bdsk-Url-1 = {https://doi.org/10.3847/1538-3881/aabc4f}}`;
 
 		<h2>In Publications</h2>
 
-		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you please cite the Astropy papers:
+		<p>If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you please cite one of the two Astropy papers as relevant for which Astropy version you used:
             <ul>
                 <li><a href="https://arxiv.org/abs/1801.02634" target="_blank">Astropy Paper II</a>
                     (<a href="http://adsabs.harvard.edu/abs/2018arXiv180102634T" target="_blank">ADS</a> -


### PR DESCRIPTION
This is a carry-over from #265.  Right now the wording on the acknowledging&citing page is "If you use Astropy for work/research presented in a publication (whether directly, or as a dependency to another package), we ask that you please cite the Astropy papers" and shows both papers.

But is that really what we want? This might be a good choice to improve "credit" for Astropy, but for "reproducibility" we really want people to cite whichever one is relevant for their work - e.g. the one closer in time to the version they are using.  This PR updates the wording to reflect that... but it shouldn't be merged until we have consensus on this.

cc @adrn @astrofrog @kelle @bsipocz 