### PR TITLE
Fix #250: Vertical spacing in team page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -697,3 +697,7 @@ color: white;
     border-right: 5px solid transparent;
     border-top: 5px solid white;
 }
+
+#roles-table td {
+	padding: 7px 5px;
+}


### PR DESCRIPTION
Fixes #250 
Adjusted padding by adding a new CSS selector to remove extra spacing in Roles table of team page.
@eteq @astrofrog Please have a look.