### PR TITLE
Fix Anaconda URL on the main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 
 	<section class="install">
 	  <h1>Install Astropy</h1>
-	  The <a href="https://store.continuum.io/cshop/anaconda/">Anaconda
+	  The <a href="https://www.anaconda.com/download/">Anaconda
 	    Python Distribution</a> includes astropy and is the recommended way to install both
 	  Python and the astropy package. Once you have Anaconda
 	  installed use the following to update to the latest version of astropy:


### PR DESCRIPTION
Hello! I just wanted to get started with AstroPy and spotted a dead link in the installation part of the main page.