### PR TITLE
Fix repository URL of reproject

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -146,7 +146,7 @@
             "provisional": false,
             "stable": true,
             "home_url": "https://reproject.readthedocs.io",
-            "repo_url": "https://github.com/astrofrog/reproject",
+            "repo_url": "https://github.com/astropy/reproject",
             "pypi_name": "reproject",
             "image": null,
             "description": "Python-based astronomical image reprojection.",


### PR DESCRIPTION
The repository of the reproject package was changed from @astrofrog to astropy, which should be reflected here.