### PR TITLE
Add a conda install example to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,12 @@
 	  Python and the astropy package. Once you have Anaconda
 	  installed use the following to update to the latest version of astropy:
           <p/><pre>conda update astropy</pre>
-          To install astropy from source into a existing Python installation, use the following:
+	  If you instead installed <a href="https://conda.io/miniconda.html">miniconda</a>,
+	  you can use
+	  	  <p/><pre>conda install astropy</pre>
+	  to install astropy and its dependencies.
+          To install astropy from source into a existing Python installation without using
+		  Anaconda, use the following:
           <p/><pre>pip install astropy</pre>
 
 


### PR DESCRIPTION
This addresses #293: if users installed conda with miniconda, they may need to `conda install astropy`.