### PR TITLE
Remove subsection "Other astronomy packages"

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -157,15 +157,6 @@
 	</table>
 -->
 
-	<h3><u>Other astronomy packages</u></h3>
-
-	<p>This section lists some packages that are not affiliated pacakges, but are useful reference (i.e. precursors, overlapping in functionality, etc). </p>
-
-	<ul>
-	<li> <a href="http://packages.python.org/Astropysics/">astropysics</a>: A library of assorted optical astronomy and astrophysics tools.  A "precursor" of sorts, in the process of getting ported to Astropy.</li>
-	<li> <a href="http://www.astro.rug.nl/software/kapteyn/">kapteyn</a>: A library primarily concerned with celestial coordinates and other transformations. Provided some of the inspiration for astropy's coordinates package. </li>
-	</ul>
-
 	</section>
 
 	<section id="affiliated-instructions">


### PR DESCRIPTION
This section is quite outdated: The described software is no longer developed or maintained, and does not work with Python 3. Referring to that software may be misleading for new users. 
Therefore, it should be removed.

Fixes #304.