### PR TITLE
Add donate buttons to web site

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -161,6 +161,15 @@
 
 	</section>
 
+	<section id="donate">
+		<h2>Contribute Financially</h2>
+
+		<p>Astropy is fiscally represented by <a href="https://numfocus.org/">NumFOCUS</a>, which accepts donations to support development of Astropy.  If you would like to donate to astropy, please see the NumFOCUS contribution page for the Astropy Project:</p>
+		<a class="button" href="https://numfocus.salsalabs.org/donate-to-astropy/index.html" target="_blank">Donate to Astropy</a>
+
+
+	</section>
+
 	<footer>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 		<script src="js/jquery.sidr.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -129,6 +129,8 @@
 		<h1>Support Astropy</h1>
 		<p>If you use Astropy in your work, we would be grateful if you could include an acknowledgment in papers and/or presentations. See <a href="acknowledging.html">Acknowledging & Citing Astropy</a> for details. </p>
 		<p>You can also purchase apparel and trinkets from <a href="http://fashion.astropy.org">fashion.astropy.org</a>, and a portion of the profits go to support the project!</p>
+		<p> If you are interested in directly financially supporting Astropy (either one-time or recurring), you can do so via our fiscal sponsor NumFOCUS: </p>
+		<a class="button" href="https://numfocus.salsalabs.org/donate-to-astropy/index.html" target="_blank">Donate to Astropy</a>
 	</section>
 
 	<footer>


### PR DESCRIPTION
Spurred on by astropy/astropy#8512 (which updated the existing button to the new NF donate site), I realized that we still only have a donate button in the core package readme.  This PR adds donate buttons to the front and "contribute" pages on the web site.  It therefore closes #168.

cc @astrofrog @kelle