### PR TITLE
Proposed affiliated package: mocpy

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1,6 +1,24 @@
 {
     "packages": [
         {
+            "name": "mocpy",
+            "maintainer": "Matthieu Baumann <matthieu.baumann@astro.unistra.fr> and Thomas Boch <thomas.boch@astro.unistra.fr>",
+            "stable": true,
+            "home_url": "https://mocpy.readthedocs.io/en/latest/",
+            "repo_url": "https://github.com/cds-astro/mocpy",
+            "pypi_name": "mocpy",
+            "description": "MOCPy is a Python library allowing easy creation, parsing and manipulation of MOCs (Multi-Order Coverage maps). These coverage maps heavily rely on the HEALPix sky partionning scheme. A MOC is therefore a set of HEALPix cells at different orders. This allows the description of any arbitrary maps on the sky.",
+            "review": {
+                "functionality": "To be filled out by the reviewer",
+                "ecointegration": "To be filled out by the reviewer",
+                "documentation": "To be filled out by the reviewer",
+                "testing": "To be filled out by the reviewer",
+                "devstatus": "To be filled out by the reviewer",
+                "python3": "To be filled out by the reviewer",
+                "last-updated": "To be filled out by the reviewer"
+            }
+        },
+        {
             "name": "specutils",
             "maintainer": "Nicholas Earl, Adam Ginsburg, Steve Crawford, and Erik Tollerud",
             "provisional": false,


### PR DESCRIPTION
**mocpy** is a Python library allowing easy creation, parsing and manipulation of MOCs (Multi-Order Coverage maps).

MOC is an [IVOA standard](http://ivoa.net/documents/MOC/) enabling description of arbitrary sky regions. Based on the HEALPix sky tessellation, it maps regions on the sky into hierarchically grouped predefined cells. Here is an example of the MOC of the P-SDSS9-r survey coming from the online [documentation](https://cds-astro.github.io/mocpy/) of mocpy.

![image](https://user-images.githubusercontent.com/2772384/55968691-ce65f800-5c7c-11e9-8fd9-8b0ed3fb82d5.png)
*Generated with the use of mocpy and matplotlib*
You can see the HEALPix cells of different order (i.e. size) forming the MOC and allowing to describe the SDSS survey.

Some features of mocpy are:
- Serialization to fits, json, and string formats. 
- Read MOC from a fits file, json, str
- Create a MOC from a SkyCoord, from HEALPix cells, from a polygon (vertices given as a SkyCoord)...
- Check for observations contained in an astropy table if they are in a MOC
- Logical operations between MOCs (e.g. union, intersection, difference, ...)
- Visualization (cf to the image above)
