### PR TITLE
Remove python-cpl from list of affiliated packages

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -400,27 +400,6 @@
             }
         },
         {
-            "name": "python-cpl",
-            "maintainer": "Ole Streicher",
-            "provisional": false,
-            "stable": false,
-            "home_url": "https://python-cpl.readthedocs.io",
-            "repo_url": "https://github.com/olebole/python-cpl",
-            "pypi_name": "python-cpl",
-            "description": "Framework to process ESO pipelines for the VLT instruments.",
-            "image": null,
-            "coordinated": false,
-            "review": {
-                "functionality": "Specialized package",
-                "ecointegration": "Partial",
-                "documentation": "Partial",
-                "testing": "Partial",
-                "devstatus": "Functional but low activity",
-                "python3": "Good",
-                "last-updated": "2017-11-08"
-            }
-        },
-        {
             "name": "astroplan",
             "maintainer": "Brett Morris",
             "provisional": false,


### PR DESCRIPTION
Python-cpl was one of the first affiliated packages. My intention to have it there was that it could serve as a start for other pipeline/data reduction framework integration modules.
This however never happened and seems to be not happen in the near future, and I have neither time nor competence to develop/push one myself. And compared to the others, it is rather trivial now.
Also, the glue to astropy is rather loose; it mainly converts the input and output files with `astropy.io.fits` into objects.

Maybe it is better to unlist it now. If at some point there is a need for a common processing framework, we may bring it back, maybe in a modified form.

The [package](https://github.com/olebole/python-cpl) ofcourse continues to exist and will be maintained ;-)