### PR TITLE
Update GSoC deputies

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -34,7 +34,7 @@
       "url" : "Astropy_GSoC_coordinator",
       "sub-role" : [],
       "lead" : ["Brigitta Sipőcz"],
-      "deputy" : ["Tom Aldcroft, Erik Tollerud"],
+      "deputy" : ["Zé Vinícius, Erik Tollerud"],
       "role-head" : [],
       "role-subhead" : [],
       "description" : [],


### PR DESCRIPTION
Adds @mirca as GSoC deputy, and remove @taldcroft (as he was there for the transition from last year).

cc @bsipocz 