### PR TITLE
Change regions affiliated package maintainers

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -682,7 +682,7 @@
         },
         {
             "name": "regions",
-            "maintainer": "Christoph Deil and Johannes King",
+            "maintainer": "Larry Bradley and Adam Ginsburg",
             "stable": false,
             "repo_url": "https://github.com/astropy/regions",
             "home_url": "https://astropy-regions.readthedocs.io",


### PR DESCRIPTION
Johannes left astronomy a year ago, and I will shortly.

@larrybradley and @keflavich agreed on the Astropy slack #regions channel to take over as maintainers. This PR implements that change for https://www.astropy.org/affiliated/index.html, they already have been co-maintaining the package and have permissions on PyPI.

@eteq - Could you please discuss this with the Astropy coordinators (if needed, since this is a coordinated package), and approve this PR or make a different suggestion?