### PR TITLE
Updating astroML dev status

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -115,9 +115,9 @@
                 "ecointegration": "Partial",
                 "documentation": "Good",
                 "testing": "Partial",
-                "devstatus": "Functional but low activity",
+                "devstatus": "Good",
                 "python3": "Yes",
-                "last-updated": "2017-11-08"
+                "last-updated": "2019-10-06"
             }
         },
         {


### PR DESCRIPTION
I propose to update the dev status for astroML. The package is stable as is, and we are also working on new functionality. 
First I though about the "Heavy development" version, but that is being used mostly for alpha versioned packages, while here two books are out with example usage of the package. The API is expected to stay backward compatible, if not it's only because of making it more in line with scikit-learn.
Bottom line, the package is not in "low activity" mode.

I was also on the verge of asking for the status to be changed for the testing, but such as we don't have one number (e.g coverage) to point to, and many of our testing are not (yet) in public CI (examples in the book manuscript, figure generations, etc.)

As for making it more astropy units aware, it's on my list. 