### PR TITLE
collapse distribution role into one section

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -122,10 +122,10 @@
 }, {
       "role" : "Distribution coordinator",
       "url" : "Distribution_coordinator",
-      "sub-role" : ["Conda", "Debian", "Fedora", "Gentoo", "ArchLinux", "MacPorts"],
-      "lead" : ["Matt Craig", "Ole Streicher", "Sergio Pascual", "Unfilled", "Médéric Boquien", "Christoph Deil"],
-      "deputy" : ["Unfilled", "Unfilled", "Unfilled", "Unfilled", "Miguel de Val-Borro, Stuart Mumford", "Hans Moritz Günther"],
-      "role-head" : ["Distribution coordinator (1 per distribution channel)"],
+      "sub-role" : [],
+      "lead" : ["Matt Craig, Ole Streicher, Sergio Pascual, Médéric Boquien"],
+      "deputy" : ["Miguel de Val-Borro, Stuart Mumford, Hans Moritz Günther"],
+      "role-head" : ["Distribution coordinators"],
       "role-subhead" : [],
       "description" : ["Create and maintain binary distribution packages for Astropy core and affiliated packages for a specific OS or package management system."],
       "sub-description" : []


### PR DESCRIPTION
As discussed in the 2018 coordination meeting (and finally acting upon now...), this PR collapses the long list of "distribution" roles into a single line.

Some confirmation from others might be good that this is *actually* what was intended - I'm not 100% sure this is what we really meant based on the coordination meeting notes ... The exact line in the notes was "Remove Distribution subroles (need some phrasing)"