### PR TITLE
Clean up roles JSON

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -56,8 +56,8 @@ $( document ).ready(function(){
             // a virtual sub-role with no heading
             if (!('sub-roles' in role)) {
                 role['sub-roles'] = [{'role': '',
-                                      'lead':role['lead'],
-                                      'deputy':role['deputy']}];
+                                      'lead': role['lead'],
+                                      'deputy': role['deputy']}];
             }
 
             //creating each row by iterating over each lead in a role
@@ -67,16 +67,16 @@ $( document ).ready(function(){
 
                 var rowSubRole = subrole['role'];
 
-                if (role['lead'] == "Unfilled") {
+                if (subrole['lead'][0] == "Unfilled") {
                     rowLead = '<a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a>';
                 } else {
-                    rowLead = subrole['lead'];
+                    rowLead = subrole['lead'].join(', ');
                 }
 
-                if (subrole['deputy'] == "Unfilled") {
+                if (subrole['deputy'][0] == ["Unfilled"]) {
                     rowDeputy = '<a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a>';
                 } else {
-                    rowDeputy = subrole['deputy'];
+                    rowDeputy = subrole['deputy'].join(', ');
                 }
 
                 //generating rows

--- a/js/functions.js
+++ b/js/functions.js
@@ -125,7 +125,7 @@ $( document ).ready(function(){
                     console.log(resp);
 
                     detail_list = '';
-                    resp["detail"].forEach(function (detail) {
+                    resp["details"].forEach(function (detail) {
                         detail_list += '<li>' + detail + '</li>';
                     });
 

--- a/roles.json
+++ b/roles.json
@@ -2,8 +2,8 @@
     {
         "role": "Coordination committee member",
         "url": "Coordination_committee_member",
-        "lead": "Tom Aldcroft, Kelle Cruz, Thomas Robitaille, Erik Tollerud",
-        "deputy": "",
+        "lead": ["Tom Aldcroft", "Kelle Cruz", "Thomas Robitaille", "Erik Tollerud"],
+        "deputy": [],
         "role-head": "Coordination committee member (4 people)",
         "responsibilities": {
             "description": "Overall coordination and management of the Astropy project, including:",
@@ -23,8 +23,8 @@
     {
         "role": "Ombudsperson",
         "url": "Ombudsperson",
-        "lead": "Steve Crawford",
-        "deputy": "",
+        "lead": ["Steve Crawford"],
+        "deputy": [],
         "role-head": "Ombudsperson",
         "responsibilities": {
             "description": "Provide a point of contact for sensitive issues separate from the coordinating committee, including:",
@@ -42,28 +42,28 @@
         "sub-roles": [
             {
                 "role": "Overall",
-                "lead": "Kelle Cruz",
-                "deputy": "Unfilled"
+                "lead": ["Kelle Cruz"],
+                "deputy": ["Unfilled"]
             },
             {
                 "role": "Twitter",
-                "lead": "Matt Craig",
-                "deputy": "Steve Crawford"
+                "lead": ["Matt Craig"],
+                "deputy": ["Steve Crawford"]
             },
             {
                 "role": "Facebook",
-                "lead": "Kelle Cruz",
-                "deputy": "Erik Tollerud"
+                "lead": ["Kelle Cruz"],
+                "deputy": ["Erik Tollerud"]
             },
             {
                 "role": "Slack",
-                "lead": "Thomas Robitaille",
-                "deputy": "Unfilled"
+                "lead": ["Thomas Robitaille"],
+                "deputy": ["Unfilled"]
             },
             {
                 "role": "Conferences",
-                "lead": "Unfilled",
-                "deputy": "Adrian Price-Whelan, Erik Tollerud, Thomas Robitaille, Kelle Cruz"
+                "lead": ["Unfilled"],
+                "deputy": ["Adrian Price-Whelan", "Erik Tollerud", "Thomas Robitaille", "Kelle Cruz"]
             }
         ],
         "responsibilities": {
@@ -78,8 +78,8 @@
     {
         "role": "Astropy GSoC coordinator",
         "url": "Astropy_GSoC_coordinator",
-        "lead": "Brigitta Sip\u0151cz",
-        "deputy": "Z\u00e9 Vin\u00edcius, Erik Tollerud",
+        "lead": ["Brigitta Sip\u0151cz"],
+        "deputy": ["Z\u00e9 Vin\u00edcius", "Erik Tollerud"],
         "role-head": "Astropy GSoC coordinator",
         "responsibilities": {
             "description": "Coordinate the participation of Astropy in the Google Summer of Code Project",
@@ -89,8 +89,8 @@
     {
         "role": "Learn Coordinator",
         "url": "Learn_coordinator",
-        "lead": "Kelle Cruz",
-        "deputy": "",
+        "lead": ["Kelle Cruz"],
+        "deputy": [],
         "role-head": "Learn coordinator",
         "responsibilities": {
             "description": "Oversee the Astropy \"Learn\" ecosystem, including:",
@@ -104,8 +104,8 @@
     {
         "role": "Documentation infrastructure maintainer",
         "url": "Documentation_infrastructure_maintainer",
-        "lead": "Thomas Robitaille",
-        "deputy": "Erik Tollerud",
+        "lead": ["Thomas Robitaille"],
+        "deputy": ["Erik Tollerud"],
         "role-head": "Documentation infrastructure maintainer",
         "responsibilities": {
             "description": "Maintain the <a href='http://docs.astropy.org/en/stable/index.html'>Astropy documentation</a> website, including:",
@@ -123,13 +123,13 @@
         "sub-roles": [
             {
                 "role": "Infrastructure",
-                "lead": "Adrian Price-Whelan",
-                "deputy": "Erik Tollerud"
+                "lead": ["Adrian Price-Whelan"],
+                "deputy": ["Erik Tollerud"]
             },
             {
                 "role": "Content",
-                "lead": "Lia Corrales",
-                "deputy": "Unfilled"
+                "lead": ["Lia Corrales"],
+                "deputy": ["Unfilled"]
             }
         ],
         "responsibilities": [
@@ -156,8 +156,8 @@
     {
         "role": "Astropy.org web page maintainer",
         "url": "Astropyorg_web_page_maintainer",
-        "lead": "Erik Tollerud",
-        "deputy": "Adrian Price-Whelan",
+        "lead": ["Erik Tollerud"],
+        "deputy": ["Adrian Price-Whelan"],
         "role-head": "Astropy.org web page maintainer",
         "responsibilities": {
             "description": "Manage the <a href='http://astropy.org'>astropy.org</a> web site, including:",
@@ -171,8 +171,8 @@
     {
         "role": "Astropy-helpers maintainer",
         "url": "Astropyhelpers_maintainer",
-        "lead": "Thomas Robitaille",
-        "deputy": "Erik Tollerud, Brigitta Sip\u0151cz",
+        "lead": ["Thomas Robitaille"],
+        "deputy": ["Erik Tollerud", "Brigitta Sip\u0151cz"],
         "role-head": "Astropy-helpers maintainer",
         "responsibilities": {
             "description": "Lead the development and maintenance of the astropy-helpers repository, including:",
@@ -187,8 +187,8 @@
     {
         "role": "Testing infrastructure maintainer",
         "url": "Testing_infrastructure_maintainer",
-        "lead": "Unfilled",
-        "deputy": "Erik Tollerud, Thomas Robitaille",
+        "lead": ["Unfilled"],
+        "deputy": ["Erik Tollerud", "Thomas Robitaille"],
         "role-head": "Testing infrastructure maintainer",
         "responsibilities": {
             "description": "Lead development and maintenance of the testing infrastructure for Astropy and the helpers, including:",
@@ -203,8 +203,8 @@
     {
         "role": "Package template maintainer",
         "url": "Packagetemplate_maintainer",
-        "lead": "Unfilled",
-        "deputy": "Thomas Robitaille, Brigitta Sip\u0151cz, Larry Bradley, Adrian Price-Whelan, Stuart Mumford",
+        "lead": ["Unfilled"],
+        "deputy": ["Thomas Robitaille", "Brigitta Sip\u0151cz", "Larry Bradley", "Adrian Price-Whelan", "Stuart Mumford"],
         "role-head": "Package-template maintainer",
         "responsibilities": {
             "description": "Lead the development of maintenance of the affiliated package package-template, which is used by affiliated packages. This includes:",
@@ -219,8 +219,8 @@
     {
         "role": "CI-helpers maintainer",
         "url": "CIhelpers_maintainer",
-        "lead": "Brigitta Sip\u0151cz",
-        "deputy": "Unfilled",
+        "lead": ["Brigitta Sip\u0151cz"],
+        "deputy": ["Unfilled"],
         "role-head": "CI-helpers maintainer",
         "responsibilities": {
             "description": "Lead the maintenance of the ci-helpers, including:",
@@ -234,8 +234,8 @@
     {
         "role": "Distribution coordinator",
         "url": "Distribution_coordinator",
-        "lead": "Matt Craig, Ole Streicher, Sergio Pascual, M\u00e9d\u00e9ric Boquien",
-        "deputy": "Miguel de Val-Borro, Stuart Mumford",
+        "lead": ["Matt Craig", "Ole Streicher", "Sergio Pascual", "M\u00e9d\u00e9ric Boquien"],
+        "deputy": ["Miguel de Val-Borro", "Stuart Mumford"],
         "role-head": "Distribution coordinators",
         "responsibilities": {
             "description": "Create and maintain binary distribution packages for Astropy core and affiliated packages for a specific OS or package management system.",
@@ -245,8 +245,8 @@
     {
         "role": "Core package release coordinator",
         "url": "Core_package_release_coordinator",
-        "lead": "Brigitta Sip\u0151cz",
-        "deputy": "Thomas Robitaille, Erik Tollerud",
+        "lead": ["Brigitta Sip\u0151cz"],
+        "deputy": ["Thomas Robitaille", "Erik Tollerud"],
         "role-head": "Core package release coordinator",
         "responsibilities": {
             "description": "Oversee the release process for the astropy core package, including:",
@@ -270,103 +270,103 @@
         "sub-roles": [
             {
                 "role": "astropy.constants",
-                "lead": "David Shupe",
-                "deputy": "Marten van Kerkwijk"
+                "lead": ["David Shupe"],
+                "deputy": ["Marten van Kerkwijk"]
             },
             {
                 "role": "astropy.convolution",
-                "lead": "Adam Ginsburg",
-                "deputy": "Axel Donath, Larry Bradley"
+                "lead": ["Adam Ginsburg"],
+                "deputy": ["Axel Donath", "Larry Bradley"]
             },
             {
                 "role": "astropy.coordinates",
-                "lead": "Erik Tollerud",
-                "deputy": "Stuart Littlefair, Adrian Price-Whelan, Juan Luis Cano Rodr\u00edguez"
+                "lead": ["Erik Tollerud"],
+                "deputy": ["Stuart Littlefair", "Adrian Price-Whelan", "Juan Luis Cano Rodr\u00edguez"]
             },
             {
                 "role": "astropy.cosmology",
-                "lead": "Unfilled",
-                "deputy": "Unfilled"
+                "lead": ["Unfilled"],
+                "deputy": ["Unfilled"]
             },
             {
                 "role": "astropy.io.ascii",
-                "lead": "Tom Aldcroft",
-                "deputy": "Hans Moritz G\u00fcnther"
+                "lead": ["Tom Aldcroft"],
+                "deputy": ["Hans Moritz G\u00fcnther"]
             },
             {
                 "role": "astropy.io.fits",
-                "lead": "Unfilled",
-                "deputy": "Simon Conseil, Michael Seifert"
+                "lead": ["Unfilled"],
+                "deputy": ["Simon Conseil", "Michael Seifert"]
             },
             {
                 "role": "astropy.io.misc",
-                "lead": "Unfilled",
-                "deputy": "Thomas Robitaille, Matteo Bachetti"
+                "lead": ["Unfilled"],
+                "deputy": ["Thomas Robitaille", "Matteo Bachetti"]
             },
             {
                 "role": "astropy.io.votable",
-                "lead": "Pey Lian Lim",
-                "deputy": "Thomas Boch, Tom Donaldson, Pey Lian Lim"
+                "lead": ["Pey Lian Lim"],
+                "deputy": ["Thomas Boch", "Tom Donaldson", "Pey Lian Lim"]
             },
             {
                 "role": "astropy.modeling",
-                "lead": "Nadia Dencheva",
-                "deputy": "Perry Greenfield, Thomas Robitaille"
+                "lead": ["Nadia Dencheva"],
+                "deputy": ["Perry Greenfield", "Thomas Robitaille"]
             },
             {
                 "role": "astropy.nddata",
-                "lead": "Matt Craig",
-                "deputy": "Steve Crawford, Michael Seifert"
+                "lead": ["Matt Craig"],
+                "deputy": ["Steve Crawford", "Michael Seifert"]
             },
             {
                 "role": "astropy.samp",
-                "lead": "Unfilled",
-                "deputy": "Unfilled"
+                "lead": ["Unfilled"],
+                "deputy": ["Unfilled"]
             },
             {
                 "role": "astropy.stats",
-                "lead": "Steve Crawford",
-                "deputy": "Larry Bradley"
+                "lead": ["Steve Crawford"],
+                "deputy": ["Larry Bradley"]
             },
             {
                 "role": "astropy.table",
-                "lead": "Tom Aldcroft",
-                "deputy": "Marten van Kerkwijk"
+                "lead": ["Tom Aldcroft"],
+                "deputy": ["Marten van Kerkwijk"]
             },
             {
                 "role": "astropy.time",
-                "lead": "Tom Aldcroft",
-                "deputy": "Marten van Kerkwijk"
+                "lead": ["Tom Aldcroft"],
+                "deputy": ["Marten van Kerkwijk"]
             },
             {
                 "role": "astropy.timeseries",
-                "lead": "Thomas Robitaille",
-                "deputy": "Brigitta Sip\u0151cz"
+                "lead": ["Thomas Robitaille"],
+                "deputy": ["Brigitta Sip\u0151cz"]
             },
             {
                 "role": "astropy.uncertainties",
-                "lead": "Erik Tollerud",
-                "deputy": "Thomas Robitaille, Marten van Kerkwijk"
+                "lead": ["Erik Tollerud"],
+                "deputy": ["Thomas Robitaille", "Marten van Kerkwijk"]
             },
             {
                 "role": "astropy.units",
-                "lead": "Marten van Kerkwijk",
-                "deputy": "Adrian Price-Whelan"
+                "lead": ["Marten van Kerkwijk"],
+                "deputy": ["Adrian Price-Whelan"]
             },
             {
                 "role": "astropy.utils",
-                "lead": "Pey Lian Lim",
-                "deputy": "Brigitta Sip\u0151cz, Erik Tollerud"
+                "lead": ["Pey Lian Lim"],
+                "deputy": ["Brigitta Sip\u0151cz", "Erik Tollerud"]
             },
             {
                 "role": "astropy.visualization",
-                "lead": "Larry Bradley",
-                "deputy": "Thomas Robitaille, Stuart Mumford"
+                "lead": ["Larry Bradley"],
+                "deputy": ["Thomas Robitaille", "Stuart Mumford"]
             },
             {
                 "role": "astropy.wcs",
-                "lead": "Unfilled",
-                "deputy": "Nadia Dencheva"
+                "lead": ["Unfilled"],
+                "deputy": ["Nadia Dencheva"]
             }
         ],
         "responsibilities": {
@@ -386,38 +386,38 @@
         "sub-roles": [
             {
                 "role": "astroquery",
-                "lead": "Adam Ginsburg, Brigitta Sip\u0151cz",
-                "deputy": "Unfilled"
+                "lead": ["Adam Ginsburg", "Brigitta Sip\u0151cz"],
+                "deputy": ["Unfilled"]
             },
             {
                 "role": "astropy-healpix",
-                "lead": "Christoph Deil",
-                "deputy": "Thomas Robitaille"
+                "lead": ["Christoph Deil"],
+                "deputy": ["Thomas Robitaille"]
             },
             {
                 "role": "photutils",
-                "lead": "Larry Bradley",
-                "deputy": "Brigitta Sip\u0151cz"
+                "lead": ["Larry Bradley"],
+                "deputy": ["Brigitta Sip\u0151cz"]
             },
             {
                 "role": "ccdproc",
-                "lead": "Matt Craig, Michael Seifert",
-                "deputy": "Steven Crawford"
+                "lead": ["Matt Craig", "Michael Seifert"],
+                "deputy": ["Steven Crawford"]
             },
             {
                 "role": "specutils",
-                "lead": "Nicholas Earl, Erik Tollerud",
-                "deputy": "Adam Ginsburg, Steve Crawford"
+                "lead": ["Nicholas Earl", "Erik Tollerud"],
+                "deputy": ["Adam Ginsburg", "Steve Crawford"]
             },
             {
                 "role": "reproject",
-                "lead": "Thomas Robitaille",
-                "deputy": "Unfilled"
+                "lead": ["Thomas Robitaille"],
+                "deputy": ["Unfilled"]
             },
             {
                 "role": "regions",
-                "lead": "Christoph Deil",
-                "deputy": "Johannes King"
+                "lead": ["Christoph Deil"],
+                "deputy": ["Johannes King"]
             }
         ],
         "responsibilities": {

--- a/roles.json
+++ b/roles.json
@@ -80,9 +80,9 @@
         "url": "Astropy_GSoC_coordinator",
         "lead": "Brigitta Sip\u0151cz",
         "deputy": "Z\u00e9 Vin\u00edcius, Erik Tollerud",
-        "role-head": null,
+        "role-head": "Astropy GSoC coordinator",
         "responsibilities": {
-            "description": null,
+            "description": "Coordinate the participation of Astropy in the Google Summer of Code Project",
             "detail": []
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -1,163 +1,433 @@
 [
     {
-      "role" : "Coordination committee member",
-      "url" : "Coordination_committee_member",
-      "sub-role" : [],
-      "lead" : ["Tom Aldcroft", "Kelle Cruz", "Thomas Robitaille", "Erik Tollerud"],
-      "deputy" : [],
-      "role-head" : ["Coordination committee member (4 people)"],
-      "role-subhead" : [],
-      "description" : ["Overall coordination and management of the Astropy project, including:"],
-      "sub-description" : ["Keeping a large-scale view of the Astropy ecosystem", "Evaluating new affiliated package submissions and review of existing affiliated packages", "Approving or rejecting Astropy APEs", "Evaluating and merging core package pull requests as needed (e.g., for sub-packages without a maintainer)", "Arbitrating disagreements in the core package, including final decisions when otherwise deadlocked", "Maintaining the list of roles and related github permissions", "Managing finances for the project", "Coordinating with NumFOCUS and other funding organizations", "Securing funding for the project via discussions and proposals to funding agencies"]
-}, {
-      "role" : "Ombudsperson",
-      "url" : "Ombudsperson",
-      "sub-role" : [],
-      "lead" : ["Steve Crawford"],
-      "deputy" : [],
-      "role-head" : ["Ombudsperson"],
-      "role-subhead" : [],
-      "description" : ["Provide a point of contact for sensitive issues separate from the coordinating committee, including:"],
-      "sub-description" : ["Monitoring the <a href='mailto:confidential@astropy.org'>confidential@astropy.org</a> email account", "Solicit and provide anonymized feedback to the astropy coordination committee regarding coordination of the project", "Assist the coordination committee and community engagement coordinator with violations of the code of conduct or other ethical concerns"]
-}, {
-      "role" : "Community engagement coordinator",
-      "url" : "Community_engagement_coordinator",
-      "sub-role" : ["Overall", "Twitter", "Facebook", "Slack", "Conferences"],
-      "lead" : ["Kelle Cruz", "Matt Craig", "Kelle Cruz", "Thomas Robitaille", "Unfilled"],
-      "deputy" : ["Unfilled", "Steve Crawford", "Erik Tollerud", "Unfilled", "Adrian Price-Whelan, Erik Tollerud, Thomas Robitaille, Kelle Cruz"],
-      "role-head" : ["Community engagement coordinator"],
-      "role-subhead" : [],
-      "description" : ["Facilitate engagement with the astropy community, including:"],
-      "sub-description" : ["Maintain the @astropy twitter account", "Monitor/moderate the Python Users in Astronomy Facebook group", "Keep track of/help organize conferences and workshops"]
-}, {
-      "role" : "Astropy GSoC coordinator",
-      "url" : "Astropy_GSoC_coordinator",
-      "sub-role" : [],
-      "lead" : ["Brigitta Sipőcz"],
-      "deputy" : ["Zé Vinícius, Erik Tollerud"],
-      "role-head" : [],
-      "role-subhead" : [],
-      "description" : [],
-      "sub-description" : []
-}, {
-      "role" : "Learn Coordinator",
-      "url" : "Learn_coordinator",
-      "sub-role" : [],
-      "lead" : ["Kelle Cruz"],
-      "deputy" : [],
-      "role-head" : ["Learn coordinator"],
-      "role-subhead" : [],
-      "description" : ["Oversee the Astropy \"Learn\" ecosystem, including:"],
-      "sub-description" : ["Ensuring that the documentation, tutorials, and guide materials are internally consistent and cover key areas of the ecosystem", "Overseeing the maintainers for the aforementioned areas", "Organizing sprints or other events focused on Astropy learning materials"]
-}, {
-      "role" : "Documentation infrastructure maintainer",
-      "url" : "Documentation_infrastructure_maintainer",
-      "sub-role" : [],
-      "lead" : ["Thomas Robitaille"],
-      "deputy" : ["Erik Tollerud"],
-      "role-head" : ["Documentation infrastructure maintainer"],
-      "role-subhead" : [],
-      "description" : ["Maintain the <a href='http://docs.astropy.org/en/stable/index.html'>Astropy documentation</a> website, including:"],
-      "sub-description" : ["Managing the Sphinx infrastructure", "Implementing changes and improvements to the documentation website", "Overseeing content (although primary responsibility for content lies with subpackage maintainers)"]
-}, {
-      "role" : "Tutorial & guides",
-      "url" : "Tutorial_&amp;_guides",
-      "sub-role" : ["Infrastructure", "Content"],
-      "lead" : ["Adrian Price-Whelan", "Lia Corrales"],
-      "deputy" : ["Erik Tollerud", "Unfilled"],
-      "role-head" : ["Tutorial & guides"],
-      "role-subhead" : [["Infrastructure maintainer"], ["Content coordinator"]],
-      "description" : [["Maintain the <a href='http://www.astropy.org/astropy-tutorials/'>Tutorials website</a>, including:"], ["Oversee the material included in Tutorials and Guides, including:"]],
-      "sub-description" : [["Facilitating the display and discoverability of the tutorials", "Rendering of the Jupyter notebooks", "Integrated testing of notebooks"], ["Reviewing issues and pull requests", "Soliciting new content as needed", "Working with Infrastructure Maintainers to maintain website"]]
-}, {
-      "role" : "Astropy.org web page maintainer",
-      "url" : "Astropyorg_web_page_maintainer",
-      "sub-role" : [],
-      "lead" : ["Erik Tollerud"],
-      "deputy" : ["Adrian Price-Whelan"],
-      "role-head" : ["Astropy.org web page maintainer"],
-      "role-subhead" : [],
-      "description" : ["Manage the <a href='http://astropy.org'>astropy.org</a> web site, including:"],
-      "sub-description" : ["Maintaining contributor/roles list", "Managing pull requests to the website repository", "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)"]
-}, {
-      "role" : "Astropy-helpers maintainer",
-      "url" : "Astropyhelpers_maintainer",
-      "sub-role" : [],
-      "lead" : ["Thomas Robitaille"],
-      "deputy" : ["Erik Tollerud, Brigitta Sipőcz"],
-      "role-head" : ["Astropy-helpers maintainer"],
-      "role-subhead" : [],
-      "description" : ["Lead the development and maintenance of the astropy-helpers repository, including:"],
-      "sub-description" : ["Managing issues/pull requests for the astropy-helpers repository", "Assisting the core package release coordinator, including performing (or helping perform) the release process for astropy-helpers during core package releases", "Performing any necessary incremental/bugfix releases between Astropy releases", "Communicating to affiliated package maintainers the availability of new versions of astropy-helpers, and assist in updating in cases where changes are not trivial"]
-}, {
-      "role" : "Testing infrastructure maintainer",
-      "url" : "Testing_infrastructure_maintainer",
-      "sub-role" : [],
-      "lead" : ["Unfilled"],
-      "deputy" : ["Erik Tollerud, Thomas Robitaille"],
-      "role-head" : ["Testing infrastructure maintainer"],
-      "role-subhead" : [],
-      "description" : ["Lead development and maintenance of the testing infrastructure for Astropy and the helpers, including:"],
-      "sub-description" : ["Managing issues/pull request for the Astropy core package regarding testing infrastructure", "Managing issues/pull requests in the repositories containing the testing plugins, and determining when new plugins are required", "Maintaining the 'metapackage' with the testing machinery (pytest-astropy at the time of this writing)", "Supporting and enabling affiliated package usage of the testing infrastructure"]
-}, {
-      "role" : "Package template maintainer",
-      "url" : "Packagetemplate_maintainer",
-      "sub-role" : [],
-      "lead" : ["Unfilled"],
-      "deputy" : ["Thomas Robitaille, Brigitta Sipőcz, Larry Bradley, Adrian Price-Whelan, Stuart Mumford"],
-      "role-head" : ["Package-template maintainer"],
-      "role-subhead" : [],
-      "description" : ["Lead the development of maintenance of the affiliated package package-template, which is used by affiliated packages. This includes:"],
-      "sub-description" : ["Managing issues/pull requests in the package-template repository", "Keeping the affiliated package-template up-to-date with the astropy-helpers", "Tag new releases from time to time, and keep the TEMPLATE_CHANGES up-to-date", "Communicate any ‘releases’ with affiliated package maintainers via the astropy-affiliated-maintainers mailing list"]
-}, {
-      "role" : "CI-helpers maintainer",
-      "url" : "CIhelpers_maintainer",
-      "sub-role" : [],
-      "lead" : ["Brigitta Sipőcz"],
-      "deputy" : ["Unfilled"],
-      "role-head" : ["CI-helpers maintainer"],
-      "role-subhead" : [],
-      "description" : ["Lead the maintenance of the ci-helpers, including:"],
-      "sub-description" : ["Managing issues/pull requests in the ci-helpers repository", "Responding in a timely fashion to breakages in CI caused e.g. by updates in conda, Travis, or AppVeyor, by including workarounds", "Advertise the ci-helpers beyond the astropy project and try to expand adoption"]
-}, {
-      "role" : "Distribution coordinator",
-      "url" : "Distribution_coordinator",
-      "sub-role" : [],
-      "lead" : ["Matt Craig, Ole Streicher, Sergio Pascual, Médéric Boquien"],
-      "deputy" : ["Miguel de Val-Borro, Stuart Mumford"],
-      "role-head" : ["Distribution coordinators"],
-      "role-subhead" : [],
-      "description" : ["Create and maintain binary distribution packages for Astropy core and affiliated packages for a specific OS or package management system."],
-      "sub-description" : []
-}, {
-      "role" : "Core package release coordinator",
-      "url" : "Core_package_release_coordinator",
-      "sub-role" : [],
-      "lead" : ["Brigitta Sipőcz"],
-      "deputy" : ["Thomas Robitaille, Erik Tollerud"],
-      "role-head" : ["Core package release coordinator"],
-      "role-subhead" : [],
-      "description" : ["Oversee the release process for the astropy core package, including:"],
-      "sub-description" : ["Performing new releases", "Coordinate releases of astropy-helpers with the astropy-helpers maintainer(s)", "Maintaining the change log and “what’s new” documentation page", "Maintaining the bugfix branches", "Updating Astropy’s PyPI entry as needed", "Working with the Community Engagement Coordinator to make release announcements via channels such as mailing lists and social media", "Notifying the Distribution Coordinators of any release", "Make sure that the package gets updated in conda and coordinate with distribution coordinators", "Keep documentation for release process up to date"]
-}, {
-      "role" : "Sub-package maintainer",
-      "url" : "Subpackage_maintainer",
-      "sub-role" : ["astropy.constants", "astropy.convolution", "astropy.coordinates", "astropy.cosmology", "astropy.io.ascii", "astropy.io.fits", "astropy.io.misc", "astropy.io.votable", "astropy.modeling", "astropy.nddata", "astropy.samp", "astropy.stats", "astropy.table", "astropy.time", "astropy.timeseries", "astropy.uncertainties","astropy.units", "astropy.utils", "astropy.visualization", "astropy.wcs"],
-      "lead" : ["David Shupe", "Adam Ginsburg", "Erik Tollerud", "Unfilled", "Tom Aldcroft", "Unfilled", "Unfilled", "Pey Lian Lim", "Nadia Dencheva", "Matt Craig", "Unfilled", "Steve Crawford", "Tom Aldcroft", "Tom Aldcroft", "Thomas Robitaille", "Erik Tollerud", "Marten van Kerkwijk", "Pey Lian Lim", "Larry Bradley", "Unfilled"],
-      "deputy" : ["Marten van Kerkwijk", "Axel Donath, Larry Bradley", "Stuart Littlefair, Adrian Price-Whelan, Juan Luis Cano Rodríguez", "Unfilled", "Hans Moritz Günther", "Simon Conseil, Michael Seifert", "Thomas Robitaille, Matteo Bachetti", "Thomas Boch, Tom Donaldson, Pey Lian Lim", "Perry Greenfield, Thomas Robitaille", "Steve Crawford, Michael Seifert", "Unfilled", "Larry Bradley", "Marten van Kerkwijk", "Marten van Kerkwijk", "Brigitta Sipőcz", "Thomas Robitaille, Marten van Kerkwijk", "Adrian Price-Whelan", "Brigitta Sipőcz, Erik Tollerud", "Thomas Robitaille, Stuart Mumford", "Nadia Dencheva"],
-      "role-head" : ["Sub-package maintainer (1 per core package sub-package)"],
-      "role-subhead" : [],
-      "description" : ["Maintain a sub-package of the astropy core package, including:"],
-      "sub-description" : ["Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem", "Merging Pull Requests in the sub-package", "Keeping track of the “big picture” progress of the sub-package - includes new feature development and significant bugs", "Keeping track of frequent contributors to the sub-package and their relevant areas of expertise"]
-}, {
-      "role" : "Coordinated package maintainer",
-      "url" : "Coordinated_package_maintainer",
-      "sub-role" : ["astroquery", "astropy-healpix", "photutils", "ccdproc", "specutils", "reproject", "regions"],
-      "lead" : ["Adam Ginsburg, Brigitta Sipőcz", "Christoph Deil", "Larry Bradley", "Matt Craig, Michael Seifert", "Nicholas Earl, Erik Tollerud", "Thomas Robitaille", "Christoph Deil"],
-      "deputy" : ["Unfilled", "Thomas Robitaille", "Brigitta Sipőcz", "Steven Crawford", "Adam Ginsburg, Steve Crawford", "Unfilled", "Johannes King"],
-      "role-head" : ["Astropy coordinated package maintainer"],
-      "role-subhead" : [],
-      "description" : ["Maintain an astropy coordinated package, including:"],
-      "sub-description" : ["Maintaining the github repository for the coordinated package", "Maintaining the coordinated package's infrastructure (usually via the helpers and package template)", "Monitoring features and bringing them for inclusion in the core package when relevant", "All the same responsilities as a sub-package, but for the coordinated package."]
+        "role": "Coordination committee member",
+        "url": "Coordination_committee_member",
+        "lead": "Tom Aldcroft, Kelle Cruz, Thomas Robitaille, Erik Tollerud",
+        "deputy": "",
+        "role-head": "Coordination committee member (4 people)",
+        "responsibilities": {
+            "description": "Overall coordination and management of the Astropy project, including:",
+            "detail": [
+                "Keeping a large-scale view of the Astropy ecosystem",
+                "Evaluating new affiliated package submissions and review of existing affiliated packages",
+                "Approving or rejecting Astropy APEs",
+                "Evaluating and merging core package pull requests as needed (e.g., for sub-packages without a maintainer)",
+                "Arbitrating disagreements in the core package, including final decisions when otherwise deadlocked",
+                "Maintaining the list of roles and related github permissions",
+                "Managing finances for the project",
+                "Coordinating with NumFOCUS and other funding organizations",
+                "Securing funding for the project via discussions and proposals to funding agencies"
+            ]
+        }
+    },
+    {
+        "role": "Ombudsperson",
+        "url": "Ombudsperson",
+        "lead": "Steve Crawford",
+        "deputy": "",
+        "role-head": "Ombudsperson",
+        "responsibilities": {
+            "description": "Provide a point of contact for sensitive issues separate from the coordinating committee, including:",
+            "detail": [
+                "Monitoring the <a href='mailto:confidential@astropy.org'>confidential@astropy.org</a> email account",
+                "Solicit and provide anonymized feedback to the astropy coordination committee regarding coordination of the project",
+                "Assist the coordination committee and community engagement coordinator with violations of the code of conduct or other ethical concerns"
+            ]
+        }
+    },
+    {
+        "role": "Community engagement coordinator",
+        "url": "Community_engagement_coordinator",
+        "role-head": "Community engagement coordinator",
+        "sub-roles": [
+            {
+                "role": "Overall",
+                "lead": "Kelle Cruz",
+                "deputy": "Unfilled"
+            },
+            {
+                "role": "Twitter",
+                "lead": "Matt Craig",
+                "deputy": "Steve Crawford"
+            },
+            {
+                "role": "Facebook",
+                "lead": "Kelle Cruz",
+                "deputy": "Erik Tollerud"
+            },
+            {
+                "role": "Slack",
+                "lead": "Thomas Robitaille",
+                "deputy": "Unfilled"
+            },
+            {
+                "role": "Conferences",
+                "lead": "Unfilled",
+                "deputy": "Adrian Price-Whelan, Erik Tollerud, Thomas Robitaille, Kelle Cruz"
+            }
+        ],
+        "responsibilities": {
+            "description": "Facilitate engagement with the astropy community, including:",
+            "detail": [
+                "Maintain the @astropy twitter account",
+                "Monitor/moderate the Python Users in Astronomy Facebook group",
+                "Keep track of/help organize conferences and workshops"
+            ]
+        }
+    },
+    {
+        "role": "Astropy GSoC coordinator",
+        "url": "Astropy_GSoC_coordinator",
+        "lead": "Brigitta Sip\u0151cz",
+        "deputy": "Z\u00e9 Vin\u00edcius, Erik Tollerud",
+        "role-head": null,
+        "responsibilities": {
+            "description": null,
+            "detail": []
+        }
+    },
+    {
+        "role": "Learn Coordinator",
+        "url": "Learn_coordinator",
+        "lead": "Kelle Cruz",
+        "deputy": "",
+        "role-head": "Learn coordinator",
+        "responsibilities": {
+            "description": "Oversee the Astropy \"Learn\" ecosystem, including:",
+            "detail": [
+                "Ensuring that the documentation, tutorials, and guide materials are internally consistent and cover key areas of the ecosystem",
+                "Overseeing the maintainers for the aforementioned areas",
+                "Organizing sprints or other events focused on Astropy learning materials"
+            ]
+        }
+    },
+    {
+        "role": "Documentation infrastructure maintainer",
+        "url": "Documentation_infrastructure_maintainer",
+        "lead": "Thomas Robitaille",
+        "deputy": "Erik Tollerud",
+        "role-head": "Documentation infrastructure maintainer",
+        "responsibilities": {
+            "description": "Maintain the <a href='http://docs.astropy.org/en/stable/index.html'>Astropy documentation</a> website, including:",
+            "detail": [
+                "Managing the Sphinx infrastructure",
+                "Implementing changes and improvements to the documentation website",
+                "Overseeing content (although primary responsibility for content lies with subpackage maintainers)"
+            ]
+        }
+    },
+    {
+        "role": "Tutorial & guides",
+        "url": "Tutorial_&amp;_guides",
+        "role-head": "Tutorial & guides",
+        "sub-roles": [
+            {
+                "role": "Infrastructure",
+                "lead": "Adrian Price-Whelan",
+                "deputy": "Erik Tollerud"
+            },
+            {
+                "role": "Content",
+                "lead": "Lia Corrales",
+                "deputy": "Unfilled"
+            }
+        ],
+        "responsibilities": [
+            {
+                "subrole-head": "Infrastructure maintainer",
+                "description": "Maintain the <a href='http://www.astropy.org/astropy-tutorials/'>Tutorials website</a>, including:",
+                "detail": [
+                    "Facilitating the display and discoverability of the tutorials",
+                    "Rendering of the Jupyter notebooks",
+                    "Integrated testing of notebooks"
+                ]
+            },
+            {
+                "subrole-head": "Content coordinator",
+                "description": "Oversee the material included in Tutorials and Guides, including:",
+                "detail": [
+                    "Reviewing issues and pull requests",
+                    "Soliciting new content as needed",
+                    "Working with Infrastructure Maintainers to maintain website"
+                ]
+            }
+        ]
+    },
+    {
+        "role": "Astropy.org web page maintainer",
+        "url": "Astropyorg_web_page_maintainer",
+        "lead": "Erik Tollerud",
+        "deputy": "Adrian Price-Whelan",
+        "role-head": "Astropy.org web page maintainer",
+        "responsibilities": {
+            "description": "Manage the <a href='http://astropy.org'>astropy.org</a> web site, including:",
+            "detail": [
+                "Maintaining contributor/roles list",
+                "Managing pull requests to the website repository",
+                "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)"
+            ]
+        }
+    },
+    {
+        "role": "Astropy-helpers maintainer",
+        "url": "Astropyhelpers_maintainer",
+        "lead": "Thomas Robitaille",
+        "deputy": "Erik Tollerud, Brigitta Sip\u0151cz",
+        "role-head": "Astropy-helpers maintainer",
+        "responsibilities": {
+            "description": "Lead the development and maintenance of the astropy-helpers repository, including:",
+            "detail": [
+                "Managing issues/pull requests for the astropy-helpers repository",
+                "Assisting the core package release coordinator, including performing (or helping perform) the release process for astropy-helpers during core package releases",
+                "Performing any necessary incremental/bugfix releases between Astropy releases",
+                "Communicating to affiliated package maintainers the availability of new versions of astropy-helpers, and assist in updating in cases where changes are not trivial"
+            ]
+        }
+    },
+    {
+        "role": "Testing infrastructure maintainer",
+        "url": "Testing_infrastructure_maintainer",
+        "lead": "Unfilled",
+        "deputy": "Erik Tollerud, Thomas Robitaille",
+        "role-head": "Testing infrastructure maintainer",
+        "responsibilities": {
+            "description": "Lead development and maintenance of the testing infrastructure for Astropy and the helpers, including:",
+            "detail": [
+                "Managing issues/pull request for the Astropy core package regarding testing infrastructure",
+                "Managing issues/pull requests in the repositories containing the testing plugins, and determining when new plugins are required",
+                "Maintaining the 'metapackage' with the testing machinery (pytest-astropy at the time of this writing)",
+                "Supporting and enabling affiliated package usage of the testing infrastructure"
+            ]
+        }
+    },
+    {
+        "role": "Package template maintainer",
+        "url": "Packagetemplate_maintainer",
+        "lead": "Unfilled",
+        "deputy": "Thomas Robitaille, Brigitta Sip\u0151cz, Larry Bradley, Adrian Price-Whelan, Stuart Mumford",
+        "role-head": "Package-template maintainer",
+        "responsibilities": {
+            "description": "Lead the development of maintenance of the affiliated package package-template, which is used by affiliated packages. This includes:",
+            "detail": [
+                "Managing issues/pull requests in the package-template repository",
+                "Keeping the affiliated package-template up-to-date with the astropy-helpers",
+                "Tag new releases from time to time, and keep the TEMPLATE_CHANGES up-to-date",
+                "Communicate any \u2018releases\u2019 with affiliated package maintainers via the astropy-affiliated-maintainers mailing list"
+            ]
+        }
+    },
+    {
+        "role": "CI-helpers maintainer",
+        "url": "CIhelpers_maintainer",
+        "lead": "Brigitta Sip\u0151cz",
+        "deputy": "Unfilled",
+        "role-head": "CI-helpers maintainer",
+        "responsibilities": {
+            "description": "Lead the maintenance of the ci-helpers, including:",
+            "detail": [
+                "Managing issues/pull requests in the ci-helpers repository",
+                "Responding in a timely fashion to breakages in CI caused e.g. by updates in conda, Travis, or AppVeyor, by including workarounds",
+                "Advertise the ci-helpers beyond the astropy project and try to expand adoption"
+            ]
+        }
+    },
+    {
+        "role": "Distribution coordinator",
+        "url": "Distribution_coordinator",
+        "lead": "Matt Craig, Ole Streicher, Sergio Pascual, M\u00e9d\u00e9ric Boquien",
+        "deputy": "Miguel de Val-Borro, Stuart Mumford",
+        "role-head": "Distribution coordinators",
+        "responsibilities": {
+            "description": "Create and maintain binary distribution packages for Astropy core and affiliated packages for a specific OS or package management system.",
+            "detail": []
+        }
+    },
+    {
+        "role": "Core package release coordinator",
+        "url": "Core_package_release_coordinator",
+        "lead": "Brigitta Sip\u0151cz",
+        "deputy": "Thomas Robitaille, Erik Tollerud",
+        "role-head": "Core package release coordinator",
+        "responsibilities": {
+            "description": "Oversee the release process for the astropy core package, including:",
+            "detail": [
+                "Performing new releases",
+                "Coordinate releases of astropy-helpers with the astropy-helpers maintainer(s)",
+                "Maintaining the change log and \u201cwhat\u2019s new\u201d documentation page",
+                "Maintaining the bugfix branches",
+                "Updating Astropy\u2019s PyPI entry as needed",
+                "Working with the Community Engagement Coordinator to make release announcements via channels such as mailing lists and social media",
+                "Notifying the Distribution Coordinators of any release",
+                "Make sure that the package gets updated in conda and coordinate with distribution coordinators",
+                "Keep documentation for release process up to date"
+            ]
+        }
+    },
+    {
+        "role": "Sub-package maintainer",
+        "url": "Subpackage_maintainer",
+        "role-head": "Sub-package maintainer (1 per core package sub-package)",
+        "sub-roles": [
+            {
+                "role": "astropy.constants",
+                "lead": "David Shupe",
+                "deputy": "Marten van Kerkwijk"
+            },
+            {
+                "role": "astropy.convolution",
+                "lead": "Adam Ginsburg",
+                "deputy": "Axel Donath, Larry Bradley"
+            },
+            {
+                "role": "astropy.coordinates",
+                "lead": "Erik Tollerud",
+                "deputy": "Stuart Littlefair, Adrian Price-Whelan, Juan Luis Cano Rodr\u00edguez"
+            },
+            {
+                "role": "astropy.cosmology",
+                "lead": "Unfilled",
+                "deputy": "Unfilled"
+            },
+            {
+                "role": "astropy.io.ascii",
+                "lead": "Tom Aldcroft",
+                "deputy": "Hans Moritz G\u00fcnther"
+            },
+            {
+                "role": "astropy.io.fits",
+                "lead": "Unfilled",
+                "deputy": "Simon Conseil, Michael Seifert"
+            },
+            {
+                "role": "astropy.io.misc",
+                "lead": "Unfilled",
+                "deputy": "Thomas Robitaille, Matteo Bachetti"
+            },
+            {
+                "role": "astropy.io.votable",
+                "lead": "Pey Lian Lim",
+                "deputy": "Thomas Boch, Tom Donaldson, Pey Lian Lim"
+            },
+            {
+                "role": "astropy.modeling",
+                "lead": "Nadia Dencheva",
+                "deputy": "Perry Greenfield, Thomas Robitaille"
+            },
+            {
+                "role": "astropy.nddata",
+                "lead": "Matt Craig",
+                "deputy": "Steve Crawford, Michael Seifert"
+            },
+            {
+                "role": "astropy.samp",
+                "lead": "Unfilled",
+                "deputy": "Unfilled"
+            },
+            {
+                "role": "astropy.stats",
+                "lead": "Steve Crawford",
+                "deputy": "Larry Bradley"
+            },
+            {
+                "role": "astropy.table",
+                "lead": "Tom Aldcroft",
+                "deputy": "Marten van Kerkwijk"
+            },
+            {
+                "role": "astropy.time",
+                "lead": "Tom Aldcroft",
+                "deputy": "Marten van Kerkwijk"
+            },
+            {
+                "role": "astropy.timeseries",
+                "lead": "Thomas Robitaille",
+                "deputy": "Brigitta Sip\u0151cz"
+            },
+            {
+                "role": "astropy.uncertainties",
+                "lead": "Erik Tollerud",
+                "deputy": "Thomas Robitaille, Marten van Kerkwijk"
+            },
+            {
+                "role": "astropy.units",
+                "lead": "Marten van Kerkwijk",
+                "deputy": "Adrian Price-Whelan"
+            },
+            {
+                "role": "astropy.utils",
+                "lead": "Pey Lian Lim",
+                "deputy": "Brigitta Sip\u0151cz, Erik Tollerud"
+            },
+            {
+                "role": "astropy.visualization",
+                "lead": "Larry Bradley",
+                "deputy": "Thomas Robitaille, Stuart Mumford"
+            },
+            {
+                "role": "astropy.wcs",
+                "lead": "Unfilled",
+                "deputy": "Nadia Dencheva"
+            }
+        ],
+        "responsibilities": {
+            "description": "Maintain a sub-package of the astropy core package, including:",
+            "detail": [
+                "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem",
+                "Merging Pull Requests in the sub-package",
+                "Keeping track of the \u201cbig picture\u201d progress of the sub-package - includes new feature development and significant bugs",
+                "Keeping track of frequent contributors to the sub-package and their relevant areas of expertise"
+            ]
+        }
+    },
+    {
+        "role": "Coordinated package maintainer",
+        "url": "Coordinated_package_maintainer",
+        "role-head": "Astropy coordinated package maintainer",
+        "sub-roles": [
+            {
+                "role": "astroquery",
+                "lead": "Adam Ginsburg, Brigitta Sip\u0151cz",
+                "deputy": "Unfilled"
+            },
+            {
+                "role": "astropy-healpix",
+                "lead": "Christoph Deil",
+                "deputy": "Thomas Robitaille"
+            },
+            {
+                "role": "photutils",
+                "lead": "Larry Bradley",
+                "deputy": "Brigitta Sip\u0151cz"
+            },
+            {
+                "role": "ccdproc",
+                "lead": "Matt Craig, Michael Seifert",
+                "deputy": "Steven Crawford"
+            },
+            {
+                "role": "specutils",
+                "lead": "Nicholas Earl, Erik Tollerud",
+                "deputy": "Adam Ginsburg, Steve Crawford"
+            },
+            {
+                "role": "reproject",
+                "lead": "Thomas Robitaille",
+                "deputy": "Unfilled"
+            },
+            {
+                "role": "regions",
+                "lead": "Christoph Deil",
+                "deputy": "Johannes King"
+            }
+        ],
+        "responsibilities": {
+            "description": "Maintain an astropy coordinated package, including:",
+            "detail": [
+                "Maintaining the github repository for the coordinated package",
+                "Maintaining the coordinated package's infrastructure (usually via the helpers and package template)",
+                "Monitoring features and bringing them for inclusion in the core package when relevant",
+                "All the same responsilities as a sub-package, but for the coordinated package."
+            ]
+        }
     }
 ]

--- a/roles.json
+++ b/roles.json
@@ -124,7 +124,7 @@
       "url" : "Distribution_coordinator",
       "sub-role" : [],
       "lead" : ["Matt Craig, Ole Streicher, Sergio Pascual, Médéric Boquien"],
-      "deputy" : ["Miguel de Val-Borro, Stuart Mumford, Hans Moritz Günther"],
+      "deputy" : ["Miguel de Val-Borro, Stuart Mumford"],
       "role-head" : ["Distribution coordinators"],
       "role-subhead" : [],
       "description" : ["Create and maintain binary distribution packages for Astropy core and affiliated packages for a specific OS or package management system."],

--- a/roles.json
+++ b/roles.json
@@ -7,7 +7,7 @@
         "role-head": "Coordination committee member (4 people)",
         "responsibilities": {
             "description": "Overall coordination and management of the Astropy project, including:",
-            "detail": [
+            "details": [
                 "Keeping a large-scale view of the Astropy ecosystem",
                 "Evaluating new affiliated package submissions and review of existing affiliated packages",
                 "Approving or rejecting Astropy APEs",
@@ -28,7 +28,7 @@
         "role-head": "Ombudsperson",
         "responsibilities": {
             "description": "Provide a point of contact for sensitive issues separate from the coordinating committee, including:",
-            "detail": [
+            "details": [
                 "Monitoring the <a href='mailto:confidential@astropy.org'>confidential@astropy.org</a> email account",
                 "Solicit and provide anonymized feedback to the astropy coordination committee regarding coordination of the project",
                 "Assist the coordination committee and community engagement coordinator with violations of the code of conduct or other ethical concerns"
@@ -68,7 +68,7 @@
         ],
         "responsibilities": {
             "description": "Facilitate engagement with the astropy community, including:",
-            "detail": [
+            "details": [
                 "Maintain the @astropy twitter account",
                 "Monitor/moderate the Python Users in Astronomy Facebook group",
                 "Keep track of/help organize conferences and workshops"
@@ -83,7 +83,7 @@
         "role-head": "Astropy GSoC coordinator",
         "responsibilities": {
             "description": "Coordinate the participation of Astropy in the Google Summer of Code Project",
-            "detail": []
+            "details": []
         }
     },
     {
@@ -94,7 +94,7 @@
         "role-head": "Learn coordinator",
         "responsibilities": {
             "description": "Oversee the Astropy \"Learn\" ecosystem, including:",
-            "detail": [
+            "details": [
                 "Ensuring that the documentation, tutorials, and guide materials are internally consistent and cover key areas of the ecosystem",
                 "Overseeing the maintainers for the aforementioned areas",
                 "Organizing sprints or other events focused on Astropy learning materials"
@@ -109,7 +109,7 @@
         "role-head": "Documentation infrastructure maintainer",
         "responsibilities": {
             "description": "Maintain the <a href='http://docs.astropy.org/en/stable/index.html'>Astropy documentation</a> website, including:",
-            "detail": [
+            "details": [
                 "Managing the Sphinx infrastructure",
                 "Implementing changes and improvements to the documentation website",
                 "Overseeing content (although primary responsibility for content lies with subpackage maintainers)"
@@ -136,7 +136,7 @@
             {
                 "subrole-head": "Infrastructure maintainer",
                 "description": "Maintain the <a href='http://www.astropy.org/astropy-tutorials/'>Tutorials website</a>, including:",
-                "detail": [
+                "details": [
                     "Facilitating the display and discoverability of the tutorials",
                     "Rendering of the Jupyter notebooks",
                     "Integrated testing of notebooks"
@@ -145,7 +145,7 @@
             {
                 "subrole-head": "Content coordinator",
                 "description": "Oversee the material included in Tutorials and Guides, including:",
-                "detail": [
+                "details": [
                     "Reviewing issues and pull requests",
                     "Soliciting new content as needed",
                     "Working with Infrastructure Maintainers to maintain website"
@@ -161,7 +161,7 @@
         "role-head": "Astropy.org web page maintainer",
         "responsibilities": {
             "description": "Manage the <a href='http://astropy.org'>astropy.org</a> web site, including:",
-            "detail": [
+            "details": [
                 "Maintaining contributor/roles list",
                 "Managing pull requests to the website repository",
                 "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)"
@@ -176,7 +176,7 @@
         "role-head": "Astropy-helpers maintainer",
         "responsibilities": {
             "description": "Lead the development and maintenance of the astropy-helpers repository, including:",
-            "detail": [
+            "details": [
                 "Managing issues/pull requests for the astropy-helpers repository",
                 "Assisting the core package release coordinator, including performing (or helping perform) the release process for astropy-helpers during core package releases",
                 "Performing any necessary incremental/bugfix releases between Astropy releases",
@@ -192,7 +192,7 @@
         "role-head": "Testing infrastructure maintainer",
         "responsibilities": {
             "description": "Lead development and maintenance of the testing infrastructure for Astropy and the helpers, including:",
-            "detail": [
+            "details": [
                 "Managing issues/pull request for the Astropy core package regarding testing infrastructure",
                 "Managing issues/pull requests in the repositories containing the testing plugins, and determining when new plugins are required",
                 "Maintaining the 'metapackage' with the testing machinery (pytest-astropy at the time of this writing)",
@@ -208,7 +208,7 @@
         "role-head": "Package-template maintainer",
         "responsibilities": {
             "description": "Lead the development of maintenance of the affiliated package package-template, which is used by affiliated packages. This includes:",
-            "detail": [
+            "details": [
                 "Managing issues/pull requests in the package-template repository",
                 "Keeping the affiliated package-template up-to-date with the astropy-helpers",
                 "Tag new releases from time to time, and keep the TEMPLATE_CHANGES up-to-date",
@@ -224,7 +224,7 @@
         "role-head": "CI-helpers maintainer",
         "responsibilities": {
             "description": "Lead the maintenance of the ci-helpers, including:",
-            "detail": [
+            "details": [
                 "Managing issues/pull requests in the ci-helpers repository",
                 "Responding in a timely fashion to breakages in CI caused e.g. by updates in conda, Travis, or AppVeyor, by including workarounds",
                 "Advertise the ci-helpers beyond the astropy project and try to expand adoption"
@@ -239,7 +239,7 @@
         "role-head": "Distribution coordinators",
         "responsibilities": {
             "description": "Create and maintain binary distribution packages for Astropy core and affiliated packages for a specific OS or package management system.",
-            "detail": []
+            "details": []
         }
     },
     {
@@ -250,7 +250,7 @@
         "role-head": "Core package release coordinator",
         "responsibilities": {
             "description": "Oversee the release process for the astropy core package, including:",
-            "detail": [
+            "details": [
                 "Performing new releases",
                 "Coordinate releases of astropy-helpers with the astropy-helpers maintainer(s)",
                 "Maintaining the change log and \u201cwhat\u2019s new\u201d documentation page",
@@ -371,7 +371,7 @@
         ],
         "responsibilities": {
             "description": "Maintain a sub-package of the astropy core package, including:",
-            "detail": [
+            "details": [
                 "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem",
                 "Merging Pull Requests in the sub-package",
                 "Keeping track of the \u201cbig picture\u201d progress of the sub-package - includes new feature development and significant bugs",
@@ -422,7 +422,7 @@
         ],
         "responsibilities": {
             "description": "Maintain an astropy coordinated package, including:",
-            "detail": [
+            "details": [
                 "Maintaining the github repository for the coordinated package",
                 "Maintaining the coordinated package's infrastructure (usually via the helpers and package template)",
                 "Monitoring features and bringing them for inclusion in the core package when relevant",

--- a/validate_roles.py
+++ b/validate_roles.py
@@ -61,12 +61,12 @@ for i, role in enumerate(roles):
         if isinstance(role['responsibilities'], list):
             for resp in role['responsibilities']:
                 error += assert_string(i, 'responsibilities[description]', resp['description'])
-                for detail in resp['detail']:
+                for detail in resp['details']:
                     error += assert_string(i, 'responsibilities[detail]', detail)
         else:
             resp = role['responsibilities']
             error += assert_string(i, 'responsibilities[description]', resp['description'])
-            for detail in resp['detail']:
+            for detail in resp['details']:
                 error += assert_string(i, 'responsibilities[detail]', detail)
 
 if error > 0:

--- a/validate_roles.py
+++ b/validate_roles.py
@@ -3,15 +3,23 @@ import sys
 import json
 from termcolor import cprint
 
-REQUIRED_KEYS = {"role", "url", "sub-role", "lead", "deputy", "role-head",
-                 "role-subhead", "description", "sub-description"}
+REQUIRED_KEYS = {"role", "url", "role-head", "responsibilities"}
 
-LIST_KEYS = {"sub-role", "lead", "deputy", "role-head", "role-subhead",
-             "description", "sub-description"}
 
-STRING_KEYS = {"role", "url"}
+def assert_list(i, key, value):
+    if isinstance(value, list):
+        return 0
+    else:
+        cprint(f"   ERROR: Key \"{key}\" for role #{i} should be a list but instead is a {type(value)}", file=sys.stderr, color='red')
+        return 1
 
-LENGTH_MATCH_KEYSETS = [{"sub-role", "lead", "deputy"}]
+
+def assert_string(i, key, value):
+    if isinstance(value, str):
+        return 0
+    else:
+        cprint(f"   ERROR: Key \"{key}\" for role #{i} should be a string but instead is a {type(value)}", file=sys.stderr, color='red')
+        return 1
 
 
 jsonfn = "roles.json"
@@ -34,34 +42,32 @@ for i, role in enumerate(roles):
             cprint(f"   ERROR: Missing key(s) for role #{i}: {key_difference}", file=sys.stderr, color='red')
             error += 1
 
-        for key, value in role.items():
-            tval = type(value)
+        error += assert_string(i, 'role', role['role'])
+        error += assert_string(i, 'url', role['url'])
+        error += assert_string(i, 'role-head', role['role-head'])
 
-            if key in LIST_KEYS:
-                if not isinstance(value, list):
-                    cprint(f"   ERROR: Key \"{key}\" for role #{i} should be a list but instead is a {tval}", file=sys.stderr, color='red')
-                    error += 1
+        if 'sub-roles' in role:
+            if 'lead' in role or 'deputy' in role:
+                cprintf(f"   ERROR: lead and deputy should not be defined at top level for role #{i} since sub-roles are defined")
+                error += 1
+            for sub_role in role['sub-roles']:
+                error += assert_string(i, 'sub-roles[role]', sub_role['role'])
+                error += assert_string(i, 'sub-roles[lead]', sub_role['lead'])
+                error += assert_string(i, 'sub-roles[deputy]', sub_role['deputy'])
+        else:
+            error += assert_string(i, 'lead', role['lead'])
+            error += assert_string(i, 'deputy', role['deputy'])
 
-            if key in STRING_KEYS:
-                if not isinstance(value, str):
-                    cprint(f"   ERROR: Key \"{key}\" for role #{i} should be a string but instead is a {tval}", file=sys.stderr, color='red')
-                    error += 1
-
-        for keyset in LENGTH_MATCH_KEYSETS:
-            # this prevents exceptions if some of the keys are missing
-            lastlen = lastkey = None
-            for key in keyset & set(role.keys()):
-                thislen = len(role[key])
-                if thislen is 0:
-                    continue
-                if lastlen is not None and thislen != lastlen:
-                    cprint(f"   ERROR: Key \"{key}\" for role #{i} is length {thislen} which does not match \"{lastkey}\" (length {lastlen})", file=sys.stderr, color='red')
-                    error += 1
-                lastlen = thislen
-                lastkey = key
-
-
-
+        if isinstance(role['responsibilities'], list):
+            for resp in role['responsibilities']:
+                error += assert_string(i, 'responsibilities[description]', resp['description'])
+                for detail in resp['detail']:
+                    error += assert_string(i, 'responsibilities[detail]', detail)
+        else:
+            resp = role['responsibilities']
+            error += assert_string(i, 'responsibilities[description]', resp['description'])
+            for detail in resp['detail']:
+                error += assert_string(i, 'responsibilities[detail]', detail)
 
 if error > 0:
     sornot = 's' if error > 1 else ''

--- a/validate_roles.py
+++ b/validate_roles.py
@@ -6,7 +6,7 @@ from termcolor import cprint
 REQUIRED_KEYS = {"role", "url", "role-head", "responsibilities"}
 
 
-def assert_list(i, key, value):
+def assert_is_list(i, key, value):
     if isinstance(value, list):
         return 0
     else:
@@ -14,7 +14,7 @@ def assert_list(i, key, value):
         return 1
 
 
-def assert_string(i, key, value):
+def assert_is_string(i, key, value):
     if isinstance(value, str):
         return 0
     else:

--- a/validate_roles.py
+++ b/validate_roles.py
@@ -52,11 +52,11 @@ for i, role in enumerate(roles):
                 error += 1
             for sub_role in role['sub-roles']:
                 error += assert_string(i, 'sub-roles[role]', sub_role['role'])
-                error += assert_string(i, 'sub-roles[lead]', sub_role['lead'])
-                error += assert_string(i, 'sub-roles[deputy]', sub_role['deputy'])
+                error += assert_list(i, 'sub-roles[lead]', sub_role['lead'])
+                error += assert_list(i, 'sub-roles[deputy]', sub_role['deputy'])
         else:
-            error += assert_string(i, 'lead', role['lead'])
-            error += assert_string(i, 'deputy', role['deputy'])
+            error += assert_list(i, 'lead', role['lead'])
+            error += assert_list(i, 'deputy', role['deputy'])
 
         if isinstance(role['responsibilities'], list):
             for resp in role['responsibilities']:

--- a/validate_roles.py
+++ b/validate_roles.py
@@ -42,32 +42,32 @@ for i, role in enumerate(roles):
             cprint(f"   ERROR: Missing key(s) for role #{i}: {key_difference}", file=sys.stderr, color='red')
             error += 1
 
-        error += assert_string(i, 'role', role['role'])
-        error += assert_string(i, 'url', role['url'])
-        error += assert_string(i, 'role-head', role['role-head'])
+        error += assert_is_string(i, 'role', role['role'])
+        error += assert_is_string(i, 'url', role['url'])
+        error += assert_is_string(i, 'role-head', role['role-head'])
 
         if 'sub-roles' in role:
             if 'lead' in role or 'deputy' in role:
                 cprintf(f"   ERROR: lead and deputy should not be defined at top level for role #{i} since sub-roles are defined")
                 error += 1
             for sub_role in role['sub-roles']:
-                error += assert_string(i, 'sub-roles[role]', sub_role['role'])
-                error += assert_list(i, 'sub-roles[lead]', sub_role['lead'])
-                error += assert_list(i, 'sub-roles[deputy]', sub_role['deputy'])
+                error += assert_is_string(i, 'sub-roles[role]', sub_role['role'])
+                error += assert_is_list(i, 'sub-roles[lead]', sub_role['lead'])
+                error += assert_is_list(i, 'sub-roles[deputy]', sub_role['deputy'])
         else:
-            error += assert_list(i, 'lead', role['lead'])
-            error += assert_list(i, 'deputy', role['deputy'])
+            error += assert_is_list(i, 'lead', role['lead'])
+            error += assert_is_list(i, 'deputy', role['deputy'])
 
         if isinstance(role['responsibilities'], list):
             for resp in role['responsibilities']:
-                error += assert_string(i, 'responsibilities[description]', resp['description'])
+                error += assert_is_string(i, 'responsibilities[description]', resp['description'])
                 for detail in resp['details']:
-                    error += assert_string(i, 'responsibilities[detail]', detail)
+                    error += assert_is_string(i, 'responsibilities[detail]', detail)
         else:
             resp = role['responsibilities']
-            error += assert_string(i, 'responsibilities[description]', resp['description'])
+            error += assert_is_string(i, 'responsibilities[description]', resp['description'])
             for detail in resp['details']:
-                error += assert_string(i, 'responsibilities[detail]', detail)
+                error += assert_is_string(i, 'responsibilities[detail]', detail)
 
 if error > 0:
     sornot = 's' if error > 1 else ''


### PR DESCRIPTION
This finally re-organizes the JSON file for the roles to be easier to read and update, in particular in relation to sub-roles. This makes the associated JS code simpler (in my opinion).

I've also removed @hamogu from the distribution role (it was for MacPorts) following his response in the roles survey, and fixed a missing description for the GSoC role that caused it to be absent from the roles descriptions.

[Preview](https://341-2081290-gh.circle-artifacts.com/0/html/team.html)

Fixes https://github.com/astropy/astropy.github.com/issues/326