### PR TITLE
Add subsection to Contribute page about justifying effort

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -77,7 +77,7 @@
 	</section>
 
 	<section id="feedback">
-		<h1 id="contribute-feedback">Contribute feedback<a class="paralink" href="#contribute-feedback" title="Permalink to this headline">¶</a></h1>
+		<h2 id="contribute-feedback">Contribute feedback<a class="paralink" href="#contribute-feedback" title="Permalink to this headline">¶</a></h2>
 
 	<p>There are several ways in which you can give feedback. </p>
 
@@ -106,7 +106,7 @@
 
 
     <section>
-    <h1 id="reporting-issues">Reporting Issues<a class="paralink" href="#reporting-issues" title="Permalink to this headline">¶</a></h1>
+    <h2 id="reporting-issues">Reporting Issues<a class="paralink" href="#reporting-issues" title="Permalink to this headline">¶</a></h2>
 
     <p>If you have found a bug in Astropy please report it. The preferred way is to
     create a new issue on the Astropy
@@ -160,12 +160,41 @@
 	</section>
 
 	<section id="donate">
-		<h2 id="contribute-financially">Contribute Financially<a class="paralink" href="#develop-affiliated-package" title="Permalink to this headline">¶</a></h2>
+		<h2 id="contribute-financially">Contribute Financially<a class="paralink" href="#contribute-financially" title="Permalink to this headline">¶</a></h2>
 
 		<p>Donations to Astropy are managed by <a href="https://numfocus.org/">NumFOCUS</a>. For donors in the United States, your gift is tax-deductible to the extent provided by law. As with any donation, you should consult with your tax adviser about your particular tax situation. If you would like to donate to astropy, please see the NumFOCUS contribution page for the Astropy Project:</p>
 
 		<a class="button" href="https://numfocus.salsalabs.org/donate-to-astropy/index.html" target="_blank">Donate to Astropy</a>
 
+
+	</section>
+
+	<section id="justify">
+		<h2 id="justify-contribution">Justifying your contribution for academics<a class="paralink" href="#justify-contribution" title="Permalink to this headline"></a></h2>
+
+		<p>Contributing to the Astropy Project as a volunteer directly benefits
+		the astronomical research community in tangible ways.  Nevertheless,
+		people employed in academic departments may be asked to justify their
+		time and efforts in terms of direct benefit to their own department or
+		organization.  In this case it is worth highlighting the
+		well-established role of community service in academia, including:
+			<ul>
+				<li>Referring journal papers</li>
+				<li>Reviewing proposals for funding or for an observatory time allocation committee</li>
+				<li>Serving on a conference science organizing committee</li>
+				<li>Serving on an external review committee such as the NASA Senior Review</li>
+			</ul>
+		</p>
+
+		<p>
+			These volunteer duties typically bring no direct benefit to the home
+			department of a researcher, yet they are widely accepted as
+			necessary to the functioning of global research astronomy. We should
+			now add the following to the above list of community service duties:
+			<ul>
+				<li>Contribute to open source software projects that benefit astronomical research</li>
+			</ul>
+		</p>
 
 	</section>
 


### PR DESCRIPTION
The primary change is adding a section about justifying the time for contributing to Astropy in an academic setting.

Along the way I noticed that the first two sub-sections were `<h1>` when they really should be `<h2>` to fit in with the rest.  I also saw that the `href` for the Donate section seems wrong.