### PR TITLE
Add @Cadair as astropy-helpers deputy maintainer

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -172,7 +172,7 @@
         "role": "Astropy-helpers maintainer",
         "url": "Astropyhelpers_maintainer",
         "lead": ["Thomas Robitaille"],
-        "deputy": ["Erik Tollerud", "Brigitta Sip\u0151cz"],
+        "deputy": ["Erik Tollerud", "Brigitta Sip\u0151cz", "Stuart Mumford"],
         "role-head": "Astropy-helpers maintainer",
         "responsibilities": {
             "description": "Lead the development and maintenance of the astropy-helpers repository, including:",


### PR DESCRIPTION
This PR is to add @Cadair as an astropy-helpers deputy maintainer - in fact this is to maintain extension-helpers, which I think we can consider part of the same role for now.