### PR TITLE
Updated maintainers for regions and astropy-healpix

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -722,7 +722,7 @@
         },
         {
            "name": "astropy-healpix",
-           "maintainer": "Christoph Deil <Deil.Christoph@gmail.com> and Thomas Robitaille <thomas.robitaille@gmail.com>",
+           "maintainer": "Thomas Robitaille <thomas.robitaille@gmail.com>",
            "stable": false,
            "repo_url": "https://github.com/astropy/astropy-healpix",
            "home_url": "https://astropy-healpix.readthedocs.io/",

--- a/roles.json
+++ b/roles.json
@@ -404,7 +404,7 @@
             },
             {
                 "role": "astropy-healpix",
-                "lead": ["Christoph Deil"],
+                "lead": ["Unfilled"],
                 "deputy": ["Thomas Robitaille"]
             },
             {
@@ -429,8 +429,8 @@
             },
             {
                 "role": "regions",
-                "lead": ["Christoph Deil"],
-                "deputy": ["Johannes King"]
+                "lead": ["Larry Bradley", "Adam Ginsburg"],
+                "deputy": ["Unfilled"]
             }
         ],
         "responsibilities": {


### PR DESCRIPTION
@cdeil, as requested, this removes you from the maintainer list for regions and astropy-healpix. Thanks for all the work you've put in to those package! :clap: :pray: :+1: Just for info, I'll remove you from the core-maintainers mailing list, and from the write-access teams for those packages.

@larrybradley @keflavich - I'd already switched to to maintainers in the affiliated package package but I'd forgotten to update the role. I've put you both under 'lead' since we're going to get rid of the lead/deputy distinction anyway.