### PR TITLE
Update mocpy web site

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -920,7 +920,7 @@
             "name": "mocpy",
             "maintainer": "Matthieu Baumann <matthieu.baumann@astro.unistra.fr> and Thomas Boch <thomas.boch@astro.unistra.fr>",
             "stable": true,
-            "home_url": "https://mocpy.readthedocs.io/en/latest/",
+            "home_url": "https://cds-astro.github.io/mocpy/",
             "repo_url": "https://github.com/cds-astro/mocpy",
             "pypi_name": "mocpy",
             "description": "MOCPy is a Python library allowing easy creation, parsing and manipulation of MOCs (Multi-Order Coverage maps). These coverage maps heavily rely on the HEALPix sky partionning scheme. A MOC is therefore a set of HEALPix cells at different orders. This allows the description of any arbitrary maps on the sky.",


### PR DESCRIPTION
mocpy's docs to have been updated to use the github pages URL instead of an RTD url.  This just updates that to get the CI back and working for this repo.

@bmatthieu3 can probably confirm that this is the right URL - please approve or :+1: if you agree with this