### PR TITLE
Update roles for @astrofrog

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -56,7 +56,7 @@
                 "deputy": ["Erik Tollerud"]
             },
             {
-                "role": "Slack",
+                "role": "Slack/Matrix",
                 "lead": ["Unfilled"],
                 "deputy": ["Unfilled"]
             },

--- a/roles.json
+++ b/roles.json
@@ -57,13 +57,13 @@
             },
             {
                 "role": "Slack",
-                "lead": ["Thomas Robitaille"],
+                "lead": ["Unfilled"],
                 "deputy": ["Unfilled"]
             },
             {
                 "role": "Conferences",
                 "lead": ["Unfilled"],
-                "deputy": ["Adrian Price-Whelan", "Erik Tollerud", "Thomas Robitaille", "Kelle Cruz"]
+                "deputy": ["Adrian Price-Whelan", "Erik Tollerud", "Kelle Cruz"]
             }
         ],
         "responsibilities": {
@@ -104,8 +104,8 @@
     {
         "role": "Documentation infrastructure maintainer",
         "url": "Documentation_infrastructure_maintainer",
-        "lead": ["Thomas Robitaille"],
-        "deputy": ["Erik Tollerud"],
+        "lead": ["Unfilled"],
+        "deputy": ["Erik Tollerud", "Thomas Robitaille"],
         "role-head": "Documentation infrastructure maintainer",
         "responsibilities": {
             "description": "Maintain the <a href='http://docs.astropy.org/en/stable/index.html'>Astropy documentation</a> website, including:",
@@ -184,7 +184,7 @@
     {
         "role": "Astropy-helpers maintainer",
         "url": "Astropyhelpers_maintainer",
-        "lead": ["Thomas Robitaille"],
+        "lead": ["Unfilled"],
         "deputy": ["Erik Tollerud", "Brigitta Sip\u0151cz", "Stuart Mumford"],
         "role-head": "Astropy-helpers maintainer",
         "responsibilities": {
@@ -314,7 +314,7 @@
             {
                 "role": "astropy.io.misc",
                 "lead": ["Unfilled"],
-                "deputy": ["Thomas Robitaille", "Matteo Bachetti"]
+                "deputy": ["Matteo Bachetti"]
             },
             {
                 "role": "astropy.io.votable",
@@ -324,7 +324,7 @@
             {
                 "role": "astropy.modeling",
                 "lead": ["Nadia Dencheva"],
-                "deputy": ["Perry Greenfield", "Thomas Robitaille"]
+                "deputy": ["Perry Greenfield"]
             },
             {
                 "role": "astropy.nddata",
@@ -353,13 +353,13 @@
             },
             {
                 "role": "astropy.timeseries",
-                "lead": ["Thomas Robitaille"],
-                "deputy": ["Brigitta Sip\u0151cz"]
+                "lead": ["Unfilled"],
+                "deputy": ["Brigitta Sip\u0151cz", "Thomas Robitaille"]
             },
             {
                 "role": "astropy.uncertainties",
                 "lead": ["Erik Tollerud"],
-                "deputy": ["Thomas Robitaille", "Marten van Kerkwijk"]
+                "deputy": ["Marten van Kerkwijk"]
             },
             {
                 "role": "astropy.units",


### PR DESCRIPTION
Since I am going to have less time to spend on the project over the coming year, I want to step down (or scale back) some of my roles in the project so that I can focus better on my remaining roles. In detail, I am:

* Stepping down as Slack moderator
* Stepping down as a conference coordinator
* Stepping down as astropy-helpers maintainer - that package is in bugfix maintenance mode anyway, so it shouldn't matter much - but I won't be able to be responsible for fixing things at short notice if anything breaks due to upstream changes in sphinx, pytest, or python, so I'm not the right person to keep an eye on or lead this
* Stepping down as astropy.io.misc maintainer - I'm not familiar with most of the sub-package anymore, so I'm not the right person to lead this
* Stepping down as astropy.modeling maintainer - my involvment was limited to helping add units support in modeling, but since then I haven't really been involved and am not the right person to review PRs.
* Stepping down as astropy.uncertainties maintainer
* Downgrading my involvement as documentation infrastructure maintainer to deputy - I can try and help review PRs, but I can't be the primary lead for this
* Downgrading from lead to deputy for astropy.timeseries

For the last two, I know that we agreed to remove the distinction between lead and deputy at some point, but since this isn't done yet I thought it would be good to update the current list to reflect my involvement better.