### PR TITLE
Added affiliated package editorial role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -169,7 +169,7 @@
     {
         "role": "Affiliated package review editor",
         "url": "Affiliated_package_review_editor",
-        "lead": ["Pey Lian Lim", "Hans Moritz G\u00fcnther"],
+        "lead": ["Hans Moritz G\u00fcnther", "Pey Lian Lim"],
         "deputy": ["Unfilled"],
         "role-head": "Affiliated package review editor",
         "responsibilities": {

--- a/roles.json
+++ b/roles.json
@@ -177,7 +177,8 @@
             "details": [
                 "Keeping track of submissions to the affiliated package ecosystem",
                 "Managing the review process for packages",
-                "Making decisions regarding accepting and rejecting packages based on reviews"
+                "Making decisions regarding accepting and rejecting packages based on reviews",
+                "Organizing the re-review of packages that have not been recently reviewed"
             ]
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -156,7 +156,7 @@
     {
         "role": "Workshops coordinator",
         "url": "Astropy_workshops_coordinator",
-        "lead": ["David Shupe, Brett Morris"],
+        "lead": ["David Shupe", "Brett Morris"],
         "deputy": ["Unfilled"],
         "role-head": "Astropy Workshops coordinator",
         "responsibilities": {
@@ -164,6 +164,21 @@
             "details": ["Maintain the astropy-workshops repository",
                         "Oversee staffing/volunteers for workshops",
                         "Identify opportunities for workshops in diverse geographic locations"]
+        }
+    },
+    {
+        "role": "Affiliated package review editor",
+        "url": "Affiliated_package_review_editor",
+        "lead": ["Pey-Lian Lim", "Hans Moritz G\u00fcnther"],
+        "deputy": ["Unfilled"],
+        "role-head": "Affiliated package review editor",
+        "responsibilities": {
+            "description": "Oversee the affiliated package submission and review process, including:",
+            "details": [
+                "Keeping track of submissions to the affiliated package ecosystem",
+                "Managing the review process for packages",
+                "Making decisions regarding accepting and rejecting packages based on reviews"
+            ]
         }
     },
     {

--- a/roles.json
+++ b/roles.json
@@ -169,7 +169,7 @@
     {
         "role": "Affiliated package review editor",
         "url": "Affiliated_package_review_editor",
-        "lead": ["Pey-Lian Lim", "Hans Moritz G\u00fcnther"],
+        "lead": ["Pey Lian Lim", "Hans Moritz G\u00fcnther"],
         "deputy": ["Unfilled"],
         "role-head": "Affiliated package review editor",
         "responsibilities": {


### PR DESCRIPTION
This adds the affiliated package editorial role to the list of roles

cc @hamogu @pllim (can't assign you for review due to team permissions for now but clearly we will need to add permissions for you for this repo)