### PR TITLE
Add "Interim finance committee role"

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -102,6 +102,22 @@
         }
     },
     {
+        "role": "Interim finance committee member",
+        "url": "finance_committee_member",
+        "lead": ["Kelle Cruz", "Hans Moritz G\u00fcnther", "John Swinbank", "Erik Tollerud", "Steve Crawford (Ombudsperson)"],
+        "deputy": [""],
+        "role-head": "Interim finance committee member",
+        "responsibilities": {
+            "description": "Plan, oversee, and disburse the Astropy project finances, including:",
+            "details": [
+		"Determine the process of paying people including project members.",
+		"Paying and overseeing people in supporting roles (e.g. documentation copy-editors, contract lawyers).",
+		"Oversee payment for services, licenses, and travel (e.g., Python in Astro, SciPy), and other miscellaneous expenses the Project already pays for.",
+		"Develop a transparent process for reporting all of the above to the Coordination Committee and wider community, related record keeping, and planning the same for future possible financial committee efforts."
+            ]
+        }
+    },
+    {
         "role": "Documentation infrastructure maintainer",
         "url": "Documentation_infrastructure_maintainer",
         "lead": ["Thomas Robitaille"],

--- a/roles.json
+++ b/roles.json
@@ -110,10 +110,10 @@
         "responsibilities": {
             "description": "Plan, oversee, and disburse the Astropy project finances, including:",
             "details": [
-		"Determine the process of paying people including project members.",
+		"Determine the process for paying people from Astropy Project-level funding.",
 		"Paying and overseeing people in supporting roles (e.g. documentation copy-editors, contract lawyers).",
 		"Oversee payment for services, licenses, and travel (e.g., Python in Astro, SciPy), and other miscellaneous expenses the Project already pays for.",
-		"Develop a transparent process for reporting all of the above to the Coordination Committee and wider community, related record keeping, and planning the same for future possible financial committee efforts."
+		"Maintain and continuously develop a transparent process for reporting all of the above to the Coordination Committee and wider community, related record keeping, and planning the same for future possible financial committee efforts."
             ]
         }
     },


### PR DESCRIPTION
While the current finance committee is only "interim" and will hopefully
be replaced soon with a more permanent construct, this committee is
beyond the theoretical planning stage and is distributing real money.
That will have an impact on the the community one way or another.
In the interest of transparancy I think it is thus warrented at this point
to list the team members on the team page. At least that's where I would
look for it if I did not know whom to complain to ;-)

Given that it's "interim", I've placed the committee between the
"coordinators" and the "maintainers" on the page, but I suggest
revisiting that once the full Astropy governance structure is worked out.