### PR TITLE
add eslavich to io.misc role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -314,7 +314,7 @@
             {
                 "role": "astropy.io.misc",
                 "lead": ["Unfilled"],
-                "deputy": ["Thomas Robitaille", "Matteo Bachetti"]
+                "deputy": ["Thomas Robitaille", "Matteo Bachetti", "Ed Slavich"]
             },
             {
                 "role": "astropy.io.votable",


### PR DESCRIPTION
This PR adds @eslavich as one of the `io.misc` deputy maintainers.  @eslavich is a prime `asdf` maintainer, so he would be focusing in `io.misc.asdf`.