### PR TITLE
Add statement about recent events

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -203,6 +203,18 @@ cite{
 	font-family: monospace;
 }
 
+section.notice {
+	font-size: 13pt;
+	font-style: italic;
+	padding: 30px;
+	margin-top: 30px;
+	border: 1px solid #FF5000;
+	webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+
+}
+
 pre{
 	background-color: #f5f5f5;
 	border: 1px solid #ddd;
@@ -481,7 +493,7 @@ section.whatsnew{
 	border:1px #E8E8E8 solid;
 	border-right-style:none;
 	border-left-style:none;
-	border-padding=1px;
+	border-padding:1px;
 	padding-top: 15px;
 	padding-bottom: 15px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -205,6 +205,7 @@ cite{
 
 section.notice {
 	font-size: 13pt;
+	line-height: 1.25em;
 	font-style: italic;
 	padding: 10px;
 	margin: 20px;

--- a/css/style.css
+++ b/css/style.css
@@ -206,8 +206,9 @@ cite{
 section.notice {
 	font-size: 13pt;
 	font-style: italic;
-	padding: 30px;
-	margin-top: 30px;
+	padding: 10px;
+	margin: 20px;
+	margin-top: 50px;
 	border: 1px solid #FF5000;
 	webkit-border-radius: 3px;
 	-moz-border-radius: 3px;
@@ -410,7 +411,6 @@ nav .pull-right{
 
 section#hero{
 	text-align: center;
-	position:absolute;
 	left:0px;
 	top:0;
 	width:100%;
@@ -489,7 +489,6 @@ section#hero div#documentation ul li a {
 /*Front Page*/
 
 section.whatsnew{
-	margin-top:420px;
 	border:1px #E8E8E8 solid;
 	border-right-style:none;
 	border-left-style:none;

--- a/index.html
+++ b/index.html
@@ -99,6 +99,10 @@ window.onload = function() {
 		<p class="acknowledge">Please remember to <a href="acknowledging.html">acknowledge and cite</a> the use of Astropy!</p>
   </section>
 
+  <section class="notice">
+	The Astropy Project acknowledges that the racist acts that have unfolded in the United States over the last few weeks are deeply upsetting, and that many members of our community are struggling as a result. As disturbing as these recent events are, they are familiar to our Black friends and colleagues, who continue to experience and witness acts of racism and violence toward their friends, family members, coworkers, classmates, and colleagues. The Astropy community <a href="https://www.astropy.org/code_of_conduct.html">is committed to supporting diversity and inclusion</a> and absolutely does not tolerate racism. Let this be a reminder that those of us who are in positions of privilege and power have a responsibility to support and advocate for the Black members of our community. This includes engaging with current events that are impacting our society and actively seeking out anti-racism resources. <a href="http://bit.ly/ANTIRACISMRESOURCES">This compilation of links</a> may be a helpful starting point.
+</section>
+
 <section class="whatsnew"><div id="prenew"></div>
 	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/4.0.html">Astropy 4.0?</a>
 	<p class="version">Current Version: 4.0.1</p>

--- a/index.html
+++ b/index.html
@@ -91,17 +91,17 @@ window.onload = function() {
 		</div>
 	</nav>
 
+    <section class="notice">
+	The Astropy Project acknowledges that the racist acts that have unfolded in the United States over the last few weeks are deeply upsetting, and that many members of our community are struggling as a result. As disturbing as these recent events are, they are familiar to our Black friends and colleagues, who continue to experience and witness acts of racism and violence toward their friends, family members, coworkers, classmates, and colleagues. The Astropy community <a href="https://www.astropy.org/code_of_conduct.html">is committed to supporting diversity and inclusion</a> and absolutely does not tolerate racism. Let this be a reminder that those of us who are in positions of privilege and power have a responsibility to support and advocate for the Black members of our community. This includes engaging with current events that are impacting our society and actively seeking out anti-racism resources. <a href="http://bit.ly/ANTIRACISMRESOURCES">This compilation of links</a> may be a helpful starting point.
+    </section>
+
 	<section id="hero">
 		<img src="images/astropy_project_logo.svg" width="524" onerror="this.src='images/astropy_project_logo.png'; this.onerror=null;" alt="Astropy: a community Python library for Astronomy" />
 		<p>The Astropy Project is a community effort to develop a <a href="http://docs.astropy.org">common core
 		package</a> for Astronomy in Python and foster an ecosystem of <a href="affiliated/index.html">interoperable
 		astronomy packages</a>.</p>
 		<p class="acknowledge">Please remember to <a href="acknowledging.html">acknowledge and cite</a> the use of Astropy!</p>
-  </section>
-
-  <section class="notice">
-	The Astropy Project acknowledges that the racist acts that have unfolded in the United States over the last few weeks are deeply upsetting, and that many members of our community are struggling as a result. As disturbing as these recent events are, they are familiar to our Black friends and colleagues, who continue to experience and witness acts of racism and violence toward their friends, family members, coworkers, classmates, and colleagues. The Astropy community <a href="https://www.astropy.org/code_of_conduct.html">is committed to supporting diversity and inclusion</a> and absolutely does not tolerate racism. Let this be a reminder that those of us who are in positions of privilege and power have a responsibility to support and advocate for the Black members of our community. This includes engaging with current events that are impacting our society and actively seeking out anti-racism resources. <a href="http://bit.ly/ANTIRACISMRESOURCES">This compilation of links</a> may be a helpful starting point.
-</section>
+    </section>
 
 <section class="whatsnew"><div id="prenew"></div>
 	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/4.0.html">Astropy 4.0?</a>


### PR DESCRIPTION
This adds an acknowledgement and statement about recent events that have taken place in the US as a banner to the astropy.org front page. The positioning is currently a bit messed up: It works if I put this after the "whatsnew" section, but the large `margin-top` setting on whatsnew squishes it upwards if I try to put it above the whatsnew, e.g. 
![image](https://user-images.githubusercontent.com/583379/83436311-a8189400-a40b-11ea-9ad9-85d8799bfa86.png)
