### PR TITLE
adds role of astropy-dev in governance.

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -100,6 +100,11 @@
 	href="http://joinslack.astropy.org">here</a>). Slack is basically a live web
 	chat.</li>
 
+	<li>If you would like to participate in discussions about Project governance and how
+		the Project is run, please join the <a href="http://groups.google.com/group/astropy-dev">
+		Developer Email List [astropy-dev]</a>.
+	</li>
+
 	</ul>
 
 	</section>

--- a/contribute.html
+++ b/contribute.html
@@ -100,7 +100,7 @@
 	href="http://joinslack.astropy.org">here</a>). Slack is basically a live web
 	chat.</li>
 
-	<li>If you would like to participate in discussions about Project governance and how
+	<li>If you would like to participate in discussions about how
 		the Project is run, please join the <a href="http://groups.google.com/group/astropy-dev">
 		Developer Email List [astropy-dev]</a>.
 	</li>

--- a/help.html
+++ b/help.html
@@ -105,7 +105,7 @@
 		</li>
 
 		<li> <a href="http://groups.google.com/group/astropy-dev">Developer Email
-		List [astropy-dev]</a> - Start discussion and ask questions about changing astropy's
+		List [astropy-dev]</a> - Start discussion and ask questions about changing Astropy's
 		behavior or adding new features. This is also the place where significant
 		announcements for contributors/developers are usually made. If you would like to
 		participate in discussion about Project governance and how the Project is run,

--- a/help.html
+++ b/help.html
@@ -98,7 +98,7 @@
 
 		<li> <a href="https://astropy.slack.com">Astropy Slack team</a> (<a
 		href="http://joinslack.astropy.org">get an account</a>) - Some developers and
-		contributors using Slack for everyday discussions. Feel free to use this
+		contributors use Slack for everyday discussions. Feel free to use this
 		forum if you have any questions about using or contributing to astropy.
 		Please browse all the available channels before posting and try to choose the most
 		relevant one.

--- a/help.html
+++ b/help.html
@@ -88,27 +88,30 @@
 		please message one of the <a
 		href="https://www.facebook.com/groups/astropython/admins/">admins</a> with a
 		brief description of your involvement in astronomy. This is a very active
-		group and the best place for beginners/learners to get help - most posts get
-		responses within a few hours.</li>
+		group and is the best place to get help. Most posts get responses within a few hours.
+		</li>
 
 		<li><a href="http://mail.python.org/mailman/listinfo/astropy">Users Email
 		List</a> - Post questions or start discussions about anything related to
 		Python programming applied to astronomy. This is an active email list and
 		most posts get a response within a few days.</li>
 
-		<li> <a href="https://astropy.slack.com">Astropy Slack team</a> (get an account <a
-		href="http://joinslack.astropy.org">here</a>)- A number of developers and
-		contributors are using Slack (which has a live web chat format)
-		for everyday discussions, so please do feel free to drop by if you have
-		questions about using or contributing to astropy. Be aware that while this
-		is a live chat forum, depending on the time of day/year there may
-		not necessarily be someone available to help, so if you don't get an answer
-		here, be sure to try out one of the other methods of communication!</li>
+		<li> <a href="https://astropy.slack.com">Astropy Slack team</a> (<a
+		href="http://joinslack.astropy.org">get an account</a>) - Some developers and
+		contributors using Slack for everyday discussions. Feel free to use this
+		forum if you have any questions about using or contributing to astropy.
+		Please browse all the available channels before posting and tro to choose the most
+		relevant one.
+		</li>
 
 		<li> <a href="http://groups.google.com/group/astropy-dev">Developer Email
-		List</a> - Start discussion and ask questions about changing Astropy's
+		List [astropy-dev]</a> - Start discussion and ask questions about changing astropy's
 		behavior or adding new features. This is also the place where significant
-		announcements for contributors/developers are usually made.</li>
+		announcements for contributors/developers are usually made. If you would like to
+		participate in discussion about Project governance and how the Project is run,
+		please join this list.
+		</li>
+
 
 	</ul>
 

--- a/help.html
+++ b/help.html
@@ -100,7 +100,7 @@
 		href="http://joinslack.astropy.org">get an account</a>) - Some developers and
 		contributors using Slack for everyday discussions. Feel free to use this
 		forum if you have any questions about using or contributing to astropy.
-		Please browse all the available channels before posting and tro to choose the most
+		Please browse all the available channels before posting and try to choose the most
 		relevant one.
 		</li>
 

--- a/help.html
+++ b/help.html
@@ -105,8 +105,8 @@
 		</li>
 
 		<li> <a href="http://groups.google.com/group/astropy-dev">Developer Email
-		List [astropy-dev]</a> - Start discussion and ask questions about changing Astropy's
-		behavior or adding new features. This is also the place where significant
+		List [astropy-dev]</a> - Start discussion and ask questions about changing or adding
+			 functionality to the <code>astropy</code> package. This is also the place where significant
 		announcements for contributors/developers are usually made. If you would like to
 		participate in discussion about how the Project is run,
 		please join this list.

--- a/help.html
+++ b/help.html
@@ -108,7 +108,7 @@
 		List [astropy-dev]</a> - Start discussion and ask questions about changing Astropy's
 		behavior or adding new features. This is also the place where significant
 		announcements for contributors/developers are usually made. If you would like to
-		participate in discussion about Project governance and how the Project is run,
+		participate in discussion about how the Project is run,
 		please join this list.
 		</li>
 


### PR DESCRIPTION
Added bit about how we use astropy-dev to discuss governance to both the Get Help page and the Contribute page. Also polished the text on other bullets to tighten it up a bit.