### PR TITLE
Added @pllim and @bsipocz to infrastructure roles

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -143,8 +143,10 @@
         "role": "Documentation infrastructure maintainer",
         "url": "Documentation_infrastructure_maintainer",
         "people": [
+            "Pey Lian Lim",
             "Thomas Robitaille",
-            "Erik Tollerud"
+            "Erik Tollerud",
+            "Brigitta Sip\u0151cz"
         ],
         "role-head": "Documentation infrastructure maintainer",
         "responsibilities": {
@@ -269,8 +271,10 @@
         "role": "Testing infrastructure maintainer",
         "url": "Testing_infrastructure_maintainer",
         "people": [
+            "Pey Lian Lim",
             "Thomas Robitaille",
-            "Erik Tollerud"
+            "Erik Tollerud",
+            "Brigitta Sip\u0151cz"
         ],
         "role-head": "Testing infrastructure maintainer",
         "responsibilities": {


### PR DESCRIPTION
@bsipocz @pllim - I've added you both to both the testing and documentation infrastructure roles.

The roles page was out of date since @bsipocz already had write access to the sphinx infrastructure (as it should be), but I've now added @bsipocz to the pytest plugin team and @pllim I've added you to both. This PR then reflects the current write access. Sorry that it took so long to do this!

@embray FYI I've also added you to the teams for the pytest and sphinx plugins to facilitate your new role!