### PR TITLE
Remove @eteq from docs and testing infrastructure roles

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -146,7 +146,6 @@
             "Simon Conseil",
             "Pey Lian Lim",
             "Thomas Robitaille",
-            "Erik Tollerud",
             "Brigitta Sip\u0151cz"
         ],
         "role-head": "Documentation infrastructure maintainer",
@@ -275,7 +274,6 @@
             "Simon Conseil",
             "Pey Lian Lim",
             "Thomas Robitaille",
-            "Erik Tollerud",
             "Brigitta Sip\u0151cz"
         ],
         "role-head": "Testing infrastructure maintainer",


### PR DESCRIPTION
As discussed by email with @eteq (since these roles are well populated)