### PR TITLE
Add new DevOps role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -281,8 +281,8 @@
             "details": [
                 "Set up and maintain continuous integration services",
                 "Ensure adequate labeling of issues and pull requests",
-                "Perform triaging of issues and pull requests, including moving between repositories",
-                "Merging non-controversial pull requests"
+                "Perform initial triaging of issues and pull requests, including moving between repositories",
+                "Merge non-controversial pull requests"
             ]
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -268,6 +268,25 @@
         }
     },
     {
+        "role": "DevOps and Operations",
+        "url": "devops_team",
+        "people": [
+            "Madison Bray",
+            "Pey Lian Lim",
+            "Brigitta Sip\u0151cz"
+        ],
+        "role-head": "DevOps and Operations",
+        "responsibilities": {
+            "description": "Ensure the smooth running of the project",
+            "details": [
+                "Set up and maintain continuous integration services",
+                "Ensure adequate labelling of issues and pull requests",
+                "Perform triaging of issues and pull requests, including moving between repositories",
+                "Merging non-controversial pull requests"
+            ]
+        }
+    },
+    {
         "role": "Testing infrastructure maintainer",
         "url": "Testing_infrastructure_maintainer",
         "people": [

--- a/roles.json
+++ b/roles.json
@@ -271,7 +271,7 @@
         "role": "DevOps and Operations",
         "url": "devops_team",
         "people": [
-            "Madison Bray",
+            "E. Madison Bray",
             "Pey Lian Lim",
             "Brigitta Sip\u0151cz"
         ],

--- a/roles.json
+++ b/roles.json
@@ -268,7 +268,7 @@
         }
     },
     {
-        "role": "DevOps and Operations",
+        "role": "DevOps and Operations Specialist",
         "url": "devops_team",
         "people": [
             "E. Madison Bray",

--- a/roles.json
+++ b/roles.json
@@ -280,7 +280,7 @@
             "description": "Ensure the smooth running of the project",
             "details": [
                 "Set up and maintain continuous integration services",
-                "Ensure adequate labelling of issues and pull requests",
+                "Ensure adequate labeling of issues and pull requests",
                 "Perform triaging of issues and pull requests, including moving between repositories",
                 "Merging non-controversial pull requests"
             ]


### PR DESCRIPTION
I'd like to suggest we move ahead with creating a 'DevOps' role that would initially be populated with @embray, @pllim and @bsipocz. I've therefore added such a role to the list here, but **mainly with placeholder information**. I'm not thrilled about the current role title, and the list of responsibilities is just a placeholder.

This role would be a significant one as it would come with admin access to all repositories in the org to enable some of the responsibilities I've listed (although we could investigate whether maintainer access is sufficient - basically whatever level is needed to make it possible to do the things).

At this point, what I'd like is for @embray @pllim @bsipocz to take a look at this and make concrete suggestions on what you'd like the role title and responsibilities to be - feel free to either make GitHub suggestions, or a PR against my branch, or commit directly to my branch if you can. Once you are happy with the PR, we could then put it to the CoCo for approval (I'd rather this approach than having the role be defined by the CoCo since @bsipocz and @pllim in particular you know best what you've been doing in this currently unofficial role and what you'd like to be able to do but not been able to for lack of permissions).

Once this is merged in, we should email astropy-dev so that people are aware of this new role.

xref https://github.com/astropy/astropy-project/issues/118 https://github.com/astropy/astropy-project/issues/136 https://github.com/astropy/astropy-project/issues/149