### PR TITLE
Remove banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ window.onload = function() {
 		package</a> for Astronomy in Python and foster an ecosystem of <a href="affiliated/index.html">interoperable
 		astronomy packages</a>.</p>
         <p>The Astropy community <a href="https://www.astropy.org/code_of_conduct.html">is committed to
-        supporting diversity and inclusion</a></p>
+        supporting diversity and inclusion</a>.</p>
         <p class="acknowledge">Please remember to <a href="acknowledging.html">acknowledge and cite</a> the use of Astropy!</p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -91,16 +91,14 @@ window.onload = function() {
 		</div>
 	</nav>
 
-    <section class="notice">
-	The Astropy Project acknowledges that the racist acts that have unfolded in the United States over the last few weeks are deeply upsetting, and that many members of our community are struggling as a result. As disturbing as these recent events are, they are familiar to our Black friends and colleagues, who continue to experience and witness acts of racism and violence toward their friends, family members, coworkers, classmates, and colleagues. The Astropy community <a href="https://www.astropy.org/code_of_conduct.html">is committed to supporting diversity and inclusion</a> and absolutely does not tolerate racism. Let this be a reminder that those of us who are in positions of privilege and power have a responsibility to support and advocate for the Black members of our community. This includes engaging with current events that are impacting our society and actively seeking out anti-racism resources. <a href="http://bit.ly/ANTIRACISMRESOURCES">This compilation of links</a> may be a helpful starting point.
-    </section>
-
 	<section id="hero">
 		<img src="images/astropy_project_logo.svg" width="524" onerror="this.src='images/astropy_project_logo.png'; this.onerror=null;" alt="Astropy: a community Python library for Astronomy" />
 		<p>The Astropy Project is a community effort to develop a <a href="http://docs.astropy.org">common core
 		package</a> for Astronomy in Python and foster an ecosystem of <a href="affiliated/index.html">interoperable
 		astronomy packages</a>.</p>
-		<p class="acknowledge">Please remember to <a href="acknowledging.html">acknowledge and cite</a> the use of Astropy!</p>
+        <p>The Astropy community <a href="https://www.astropy.org/code_of_conduct.html">is committed to
+        supporting diversity and inclusion</a></p>
+        <p class="acknowledge">Please remember to <a href="acknowledging.html">acknowledge and cite</a> the use of Astropy!</p>
     </section>
 
 <section class="whatsnew"><div id="prenew"></div>


### PR DESCRIPTION
While this banner was added at the peak of the events earlier this year, it might be time to remove this banner and perhaps replace it with a more general statement such as the one suggested here

<img width="642" alt="Screenshot 2020-10-09 at 10 59 09" src="https://user-images.githubusercontent.com/314716/95570220-82854200-0a1e-11eb-8d71-875afc23a9dd.png">
