### PR TITLE
Update for release 4.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,8 +102,8 @@ window.onload = function() {
     </section>
 
 <section class="whatsnew"><div id="prenew"></div>
-	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/4.0.html">Astropy 4.0?</a>
-	<p class="version">Current Version: 4.0.3</p>
+	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/4.1.html">Astropy 4.1?</a>
+	<p class="version">Current Version: 4.1</p>
 
 </section>
 

--- a/team.html
+++ b/team.html
@@ -158,6 +158,7 @@
 <li>  Aniket Kulkarni </li>
 <li>  Anirudh Katipally </li>
 <li>  Anne Archibald </li>
+<li>  Antetokounpo </li>
 <li>  Anthony Horton </li>
 <li>  Antony Lee </li>
 <li>  Arfon Smith </li>
@@ -182,8 +183,11 @@
 <li>  Bryce Kalmbach </li>
 <li>  Bryce Nordgren </li>
 <li>  Carl Osterwisch </li>
+<li>  Carl Schaffer </li>
 <li>  Chris Beaumont </li>
 <li>  Chris Hanley </li>
+<li>  Chris Osborne </li>
+<li>  Chris Simpson </li>
 <li>  Christian Clauss </li>
 <li>  Christian Hettlage </li>
 <li>  Christoph Deil </li>
@@ -201,6 +205,7 @@
 <li>  Daniel D'Avella </li>
 <li>  Daniel Datsev </li>
 <li>  Daniel Lenz </li>
+<li>  Daniel Ruschel Dutra </li>
 <li>  Danny Goldstein </li>
 <li>  Daria Cara </li>
 <li>  David Kirkby </li>
@@ -217,6 +222,7 @@
 <li>  Drew Leonard </li>
 <li>  Duncan Macleod </li>
 <li>  Dylan Gregersen </li>
+<li>  Ed Slavich </li>
 <li>  Edward Betts </li>
 <li>  Eli Bressert </li>
 <li>  Elijah Bernstein-Cooper </li>
@@ -228,6 +234,7 @@
 <li>  Eric Koch </li>
 <li>  Erik M. Bray </li>
 <li>  Erik Tollerud </li>
+<li>  Erin Allard </li>
 <li>  Esteban Pardo Sánchez </li>
 <li>  Evert Rol </li>
 <li>  Felix Yan </li>
@@ -237,6 +244,7 @@
 <li>  Frédéric Chapoton </li>
 <li>  Frédéric Grollier </li>
 <li>  Gabriel Brammer </li>
+<li>  Gabriel Perren </li>
 <li>  Geert Barentsen </li>
 <li>  Georgiana Ogrean </li>
 <li>  Gerrit Schellenberger </li>
@@ -249,6 +257,7 @@
 <li>  Gustavo Bragança </li>
 <li>  Hannes Breytenbach </li>
 <li>  Hans Moritz Günther </li>
+<li>  Harry Ferguson </li>
 <li>  Helen Sherwood-Taylor </li>
 <li>  Henry Ferguson </li>
 <li>  Himanshu Pathak </li>
@@ -263,6 +272,7 @@
 <li>  James Noss </li>
 <li>  James Taylor </li>
 <li>  James Turner </li>
+<li>  Jan Skowron </li>
 <li>  Jane Rigby </li>
 <li>  Jani Šumak </li>
 <li>  Javier Pascual Granado </li>
@@ -321,13 +331,17 @@
 <li>  Lisa Walter </li>
 <li>  Luigi Paioro </li>
 <li>  Luke G. Bouma </li>
+<li>  Luke Kelley </li>
 <li>  M Atakan Gürkan </li>
+<li>  M S R Dinesh </li>
 <li>  Mabry Cervin </li>
 <li>  Madhura Parikh </li>
+<li>  Magali Mebsout </li>
 <li>  Manas Satish Bedmutha </li>
 <li>  Maneesh Yadav </li>
 <li>  Mangala Gowri Krishnamoorthy </li>
 <li>  Manish Biswas </li>
+<li>  Manodeep Sinha </li>
 <li>  Mark Fardal </li>
 <li>  Mark Taylor </li>
 <li>  Marten van Kerkwijk </li>
@@ -343,11 +357,14 @@
 <li>  Matthew Turk </li>
 <li>  Mavani Bhautik </li>
 <li>  Max Silbiger </li>
+<li>  Max Voronkov </li>
 <li>  Maximilian Nöthe </li>
 <li>  Médéric Boquien </li>
 <li>  Megan Sosey </li>
 <li>  Michael Droettboom </li>
+<li>  Michael Hirsch </li>
 <li>  Michael Hoenig </li>
+<li>  Michael Lindner-D'Addario </li>
 <li>  Michael Mueller </li>
 <li>  Michael Seifert </li>
 <li>  Michael Wood-Vasey </li>
@@ -359,22 +376,29 @@
 <li>  Mike Alexandersen </li>
 <li>  Mike McCarty </li>
 <li>  Mikhail Minin </li>
+<li>  Mikołaj </li>
 <li>  Miruna Oprescu </li>
 <li>  Moataz Hisham </li>
 <li>  Mohan Agrawal </li>
 <li>  Molly Peeples </li>
 <li>  Nabil Freij </li>
 <li>  Nadia Dencheva </li>
+<li>  Nathanial Hendler </li>
+<li>  Nathaniel Starkman </li>
+<li>  Neal McBurnett </li>
 <li>  Neil Crighton </li>
 <li>  Neil Parley </li>
+<li>  Nicholas Earl </li>
 <li>  Nicholas S. Kern </li>
 <li>  Nicholas Saunders </li>
+<li>  Nick Lloyd </li>
 <li>  Nick Murphy </li>
 <li>  Nimit Bhardwaj </li>
 <li>  Noah Zuckman </li>
 <li>  Nora Luetzgendorf </li>
 <li>  Ole Streicher </li>
 <li>  Orion Poplawski </li>
+<li>  Parikshit Sakurikar </li>
 <li>  Patricio Rojo </li>
 <li>  Patti Carroll </li>
 <li>  Paul Barrett </li>
@@ -383,6 +407,7 @@
 <li>  Paul Sladen </li>
 <li>  Pauline Barmby </li>
 <li>  Perry Greenfield </li>
+<li>  Peter Cock </li>
 <li>  Peter Teuben </li>
 <li>  Pey Lian Lim </li>
 <li>  Prasanth Nair </li>
@@ -394,14 +419,17 @@
 <li>  Ray Plante </li>
 <li>  Régis Terrier </li>
 <li>  Ricardo Ogando </li>
+<li>  Ricky O'Steen </li>
 <li>  Ritiek Malhotra </li>
 <li>  Ritwick DSouza </li>
 <li>  Roban Hultman Kramer </li>
+<li>  Robel Geda </li>
 <li>  Robert Cross </li>
 <li>  Rocio Kiman </li>
 <li>  Rohan Rajpal </li>
 <li>  Rohit Kapoor </li>
 <li>  Rohit Patil </li>
+<li>  Roman Tolesnikov </li>
 <li>  Rui Xue </li>
 <li>  Ryan Abernathey </li>
 <li>  Ryan Cooke </li>
@@ -421,7 +449,9 @@
 <li>  SF Graves </li>
 <li>  Shailesh Ahuja </li>
 <li>  Shantanu Srivastava </li>
+<li>  Shilpi Jain </li>
 <li>  Shivan Sornarajah </li>
+<li>  Shivansh Mishra </li>
 <li>  Shresth Verma </li>
 <li>  Shreyas Bapat </li>
 <li>  Sigurd Næss </li>
@@ -472,6 +502,7 @@
 <li>  Zach Edwards </li>
 <li>  Zachary Kurtz </li>
 <li>  Zeljko Ivezic </li>
+<li>  Zlatan Vasović </li>
 <li>  Zé Vinicius </li>
 		</ul>
 

--- a/team.html
+++ b/team.html
@@ -257,7 +257,6 @@
 <li>  Gustavo Bragança </li>
 <li>  Hannes Breytenbach </li>
 <li>  Hans Moritz Günther </li>
-<li>  Harry Ferguson </li>
 <li>  Helen Sherwood-Taylor </li>
 <li>  Henry Ferguson </li>
 <li>  Himanshu Pathak </li>


### PR DESCRIPTION
This updates the current version to version 4.1 as well as the contributor list update (I'll do a follow-on PR with the announcement once the conda builds are ready)