### PR TITLE
Change gala pypi name

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -505,7 +505,7 @@
             "stable": true,
             "home_url": "http://gala.adrian.pw/en/latest/",
             "repo_url": "https://github.com/adrn/gala",
-            "pypi_name": "astro-gala",
+            "pypi_name": "gala",
             "image": null,
             "description": "A Python package for gravitational and galactic dynamics. gala contains functionality for representing gravitational potential models, numerically integrating orbits, and non-linear dynamics. gala also relies heavily on Astropy's unit and coordinates subpackages.",
             "coordinated": false,

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -507,7 +507,7 @@
             "repo_url": "https://github.com/adrn/gala",
             "pypi_name": "gala",
             "image": null,
-            "description": "A Python package for gravitational and galactic dynamics. gala contains functionality for representing gravitational potential models, numerically integrating orbits, and non-linear dynamics. gala also relies heavily on Astropy's unit and coordinates subpackages.",
+            "description": "A Python package for gravitational and galactic dynamics. gala contains functionality for representing gravitational potential models, numerically integrating orbits, and non-linear dynamics. gala also relies heavily on Astropy's unit and coordinates subpackages. (Note: this was previously listed on pypi as 'astro-gala', and older versions can still be installed with that name)",
             "coordinated": false,
             "review": {
                 "functionality": "Specialized package",


### PR DESCRIPTION
I recently got access to the name "gala", bringing the pypi name and the github repo name in line, so I will be using this name going forward (🎉).