### PR TITLE
Add section to Contribute page for Astropy role

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -161,20 +161,22 @@
 		href="#formal-project-role" title="Permalink to this headline">¶</a></h2>
 
 		<p>
-            A higher level of contribution to the project comes in the form of assuming a formal
-            project role as listed in the <a href="team.html">Astropy Team</a> page.
+            AIf you are interested in a higher level of contribution to the project, you can consider taking on one of the formal
+            project roles as listed in the <a href="team.html">Astropy Team</a> page.
             </p>
         <p>
             In order to be nominated for a named Astropy role, it is typical that a person will have
             been actively involved in the project for a considerable amount of time (at least a year
             and often longer) and have made substantial contributions. They will have shown a
-            sustained commitment to Astropy by participating actively already in the role
-            responsibilities. This could involve submitting pull requests and participating in
-            reviews, or discussions in other channels such as mailing lists or slack, or other
+            sustained commitment to Astropy by participating actively already in activities related
+            to the role. This could involve submitting pull requests and participating in
+            reviews, or discussions in other channels such as mailing lists or Slack, or other
             contributions as defined by a particular role. Finally, they need to express a desire to
             maintain this involvement going forward and accept the responsibility of having a role.
             For example, being a core sub-package maintainer involves interacting with users and
-            responding to bug reports in a timely manner.
+            responding to bug reports in a timely manner. If you are interested in taking on such a role, you can volunteer
+            either on `astropy-dev` or by talking to a holder of the role you are interested in, or a coordination commitee 
+            member.
         </p>
 
 	</section>

--- a/contribute.html
+++ b/contribute.html
@@ -157,7 +157,7 @@
 	</section>
 
 	<section id="role">
-		<h2 id="formal-project-role">Formal project role<a class="paralink"
+		<h2 id="formal-project-role">Taking on a formal project role<a class="paralink"
 		href="#formal-project-role" title="Permalink to this headline">¶</a></h2>
 
 		<p>

--- a/contribute.html
+++ b/contribute.html
@@ -156,6 +156,29 @@
 
 	</section>
 
+	<section id="role">
+		<h2 id="formal-project-role">Formal project role<a class="paralink"
+		href="#formal-project-role" title="Permalink to this headline">¶</a></h2>
+
+		<p>
+            A higher level of contribution to the project comes in the form of assuming a formal
+            project role as listed in the <a href="team.html">Astropy Team</a> page.
+            </p>
+        <p>
+            In order to be nominated for a named Astropy role, it is typical that a person will have
+            been actively involved in the project for a considerable amount of time (at least a year
+            and often longer) and have made substantial contributions. They will have shown a
+            sustained commitment to Astropy by participating actively already in the role
+            responsibilities. This could involve submitting pull requests and participating in
+            reviews, or discussions in other channels such as mailing lists or slack, or other
+            contributions as defined by a particular role. Finally, they need to express a desire to
+            maintain this involvement going forward and accept the responsibility of having a role.
+            For example, being a core sub-package maintainer involves interacting with users and
+            responding to bug reports in a timely manner.
+        </p>
+
+	</section>
+
 	<section id="affiliated">
 		<h2 id="develop-affiliated-package">Develop an affiliated package<a class="paralink" href="#develop-affiliated-package" title="Permalink to this headline">¶</a></h2>
 


### PR DESCRIPTION
This adds a new section which describes assuming a formal Astropy Role as a way to contribute to Astropy.