### PR TITLE
Contribute page cleanup & ToC

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -73,7 +73,13 @@
 		<h1 id="contribute-to-astropy">Contribute to Astropy<a class="paralink" href="#contribute-to-astropy" title="Permalink to this headline">¶</a></h1>
 
 		<p>The Astropy project is made both by and for its users, so we accept contributions of many kinds. We always welcome contributors who will abide by the <a href="about.html#codeofconduct">Astropy Community Code of Conduct</a>.</p>
-
+    <a href="#contribute-feedback">Feedback</a> |
+    <a href="#reporting-issues">Report an issue</a> |
+    <a href="#contribute-code-or-docs">Code/docs</a> |
+    <a href="#formal-project-role">Project Role</a> |
+    <a href="#develop-affiliated-package">Affiliated Package</a> |
+    <a href="#contribute-financially">Financial</a> |
+    <a href="#justify-contribution">Academic Contributions</a>
 	</section>
 
 	<section id="feedback">
@@ -197,7 +203,7 @@
 	</section>
 
 	<section id="justify">
-		<h2 id="justify-contribution">For academics: How to justify your contribution<a class="paralink" href="#justify-contribution" title="Permalink to this headline"></a></h2>
+		<h2 id="justify-contribution">For academics: How to justify your contribution<a class="paralink" href="#justify-contribution" title="Permalink to this headline">¶</a></h2>
     <p> While in some more technical areas, contributing code is recognized as a
       goal in and of itself, some academic fields have not yet developed a clear
       understanding of the role of code development relative to other more

--- a/contribute.html
+++ b/contribute.html
@@ -21,16 +21,16 @@
 <body>
 
 <div id="wrapper">
-	<nav>
-		<div id="mobile-header">
-			<!-- Menu Icon -->
-		    <a id="responsive-menu-button" href="#sidr-main"><div><svg senable-background="new 0 0 24 24" height="24px" id="Layer_1" version="1.1" viewBox="0 0 24 24" width="24px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g><g><path d="M23.244,17.009H0.75c-0.413,0-0.75,0.36-0.75,0.801v3.421C0,21.654,0.337,22,0.75,22h22.494c0.414,0,0.75-0.346,0.75-0.77    V17.81C23.994,17.369,23.658,17.009,23.244,17.009z M23.244,9.009H0.75C0.337,9.009,0,9.369,0,9.81v3.421    c0,0.424,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.345,0.75-0.769V9.81C23.994,9.369,23.658,9.009,23.244,9.009z     M23.244,1.009H0.75C0.337,1.009,0,1.369,0,1.81V5.23c0,0.423,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.346,0.75-0.769V1.81    C23.994,1.369,23.658,1.009,23.244,1.009z"/></g></g></svg></div></a>
-		    <!-- -->
-		</div>
-		<a href="index.html"><img src="images/astropy_word.svg" height="32" onerror="this.src='images/astropy_word_32.png; this.onerror=null;"/></a>
-		<div id="navigation">
-			<ul>
-		    <li>
+  <nav>
+  <div id="mobile-header">
+  <!-- Menu Icon -->
+      <a id="responsive-menu-button" href="#sidr-main"><div><svg senable-background="new 0 0 24 24" height="24px" id="Layer_1" version="1.1" viewBox="0 0 24 24" width="24px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g><g><path d="M23.244,17.009H0.75c-0.413,0-0.75,0.36-0.75,0.801v3.421C0,21.654,0.337,22,0.75,22h22.494c0.414,0,0.75-0.346,0.75-0.77    V17.81C23.994,17.369,23.658,17.009,23.244,17.009z M23.244,9.009H0.75C0.337,9.009,0,9.369,0,9.81v3.421    c0,0.424,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.345,0.75-0.769V9.81C23.994,9.369,23.658,9.009,23.244,9.009z     M23.244,1.009H0.75C0.337,1.009,0,1.369,0,1.81V5.23c0,0.423,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.346,0.75-0.769V1.81    C23.994,1.369,23.658,1.009,23.244,1.009z"/></g></g></svg></div></a>
+      <!-- -->
+  </div>
+  <a href="index.html"><img src="images/astropy_word.svg" height="32" onerror="this.src='images/astropy_word_32.png; this.onerror=null;"/></a>
+  <div id="navigation">
+  <ul>
+      <li>
                 <div class="dropdown">
                   <a>About</a>
                   <div class="dropdown-content">
@@ -41,38 +41,38 @@
                     </ul>
                   </div>
                 </div>
-			    </li>
-				<li><a href="help.html">Get Help</a></li>
-				<li><a href="contribute.html">Contribute</a></li>
-				<li>
-					<div class="dropdown">
-						<a href="http://docs.astropy.org">Documentation</a>
-						<div class="dropdown-content">
-							<ul>
-								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
-							</ul>
-						</div>
-					</div>
-				</li>
-				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
+      </li>
+  <li><a href="help.html">Get Help</a></li>
+  <li><a href="contribute.html">Contribute</a></li>
+  <li>
+  <div class="dropdown">
+  <a href="http://docs.astropy.org">Documentation</a>
+  <div class="dropdown-content">
+  <ul>
+  <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
+  <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+  <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
+  </ul>
+  </div>
+  </div>
+  </li>
+  <li><a href="affiliated/index.html">Affiliated Packages</a></li>
                 <li><a href="team.html">Team</a></li>
-			</ul>
-		</div>
-		<div class="search pull-right">
-			<form action="http://docs.astropy.org/en/stable/search.html" method="get">
-			  <input type="text" name="q" placeholder="Search Documentation" />
-			  <input type="hidden" name="check_keywords" value="yes" />
-			  <input type="hidden" name="area" value="default" />
-			</form>
-		</div>
-	</nav>
+  </ul>
+  </div>
+  <div class="search pull-right">
+  <form action="http://docs.astropy.org/en/stable/search.html" method="get">
+    <input type="text" name="q" placeholder="Search Documentation" />
+    <input type="hidden" name="check_keywords" value="yes" />
+    <input type="hidden" name="area" value="default" />
+  </form>
+  </div>
+  </nav>
 
-	<section>
-		<h1 id="contribute-to-astropy">Contribute to Astropy<a class="paralink" href="#contribute-to-astropy" title="Permalink to this headline">¶</a></h1>
+  <section>
+  <h1 id="contribute-to-astropy">Contribute to Astropy<a class="paralink" href="#contribute-to-astropy" title="Permalink to this headline">¶</a></h1>
 
-		<p>The Astropy project is made both by and for its users, so we accept contributions of many kinds. We always welcome contributors who will abide by the <a href="about.html#codeofconduct">Astropy Community Code of Conduct</a>.</p>
+  <p>The Astropy project is made both by and for its users, so we accept contributions of many kinds. We always welcome contributors who will abide by the <a href="about.html#codeofconduct">Astropy Community Code of Conduct</a>.</p>
     <a href="#contribute-feedback">Feedback</a> |
     <a href="#reporting-issues">Report an issue</a> |
     <a href="#contribute-code-or-docs">Code/docs</a> |
@@ -80,40 +80,40 @@
     <a href="#develop-affiliated-package">Affiliated Package</a> |
     <a href="#contribute-financially">Financial</a> |
     <a href="#justify-contribution">Academic Contributions</a>
-	</section>
+  </section>
 
-	<section id="feedback">
-		<h2 id="contribute-feedback">Contribute feedback<a class="paralink" href="#contribute-feedback" title="Permalink to this headline">¶</a></h2>
+  <section id="feedback">
+  <h2 id="contribute-feedback">Contribute feedback<a class="paralink" href="#contribute-feedback" title="Permalink to this headline">¶</a></h2>
 
-	<p>There are several ways in which you can give feedback. </p>
+  <p>There are several ways in which you can give feedback. </p>
 
-	<ul>
-	<li>If you would like to give feedback and participate in discussions, we encourage you
-	to join the <a href="http://mail.python.org/mailman/listinfo/astropy"> astropy mailing
-	list </a> and post there. This is the easiest way to have a discussion with both developers
-	and other users.  </li>
+  <ul>
+  <li>If you would like to give feedback and participate in discussions, we encourage you
+  to join the <a href="http://mail.python.org/mailman/listinfo/astropy"> astropy mailing
+  list </a> and post there. This is the easiest way to have a discussion with both developers
+  and other users.  </li>
 
-	<li>Feature requests from the community are welcome and encouraged. </li>
+  <li>Feature requests from the community are welcome and encouraged. </li>
 
-	<li>If you have feedback you would prefer to keep private, you can e-mail <a
-	href="mailto:feedback@astropy.org">feedback@astropy.org</a>. This address
-	points to a private mailing list that includes the astropy core developers. If
-	you would like a reply (e.g., an acknowledgement of your comment), please
-	request it.</li>
+  <li>If you have feedback you would prefer to keep private, you can e-mail <a
+  href="mailto:feedback@astropy.org">feedback@astropy.org</a>. This address
+  points to a private mailing list that includes the astropy core developers. If
+  you would like a reply (e.g., an acknowledgement of your comment), please
+  request it.</li>
 
-	<li>For the extremely impatient, astropy developers often can be found in the
-	<a href="https://astropy.slack.com">Astropy Slack team</a> (get an account <a
-	href="http://joinslack.astropy.org">here</a>). Slack is basically a live web
-	chat.</li>
+  <li>For the extremely impatient, astropy developers often can be found in the
+  <a href="https://astropy.slack.com">Astropy Slack team</a> (get an account <a
+  href="http://joinslack.astropy.org">here</a>). Slack is basically a live web
+  chat.</li>
 
-	<li>If you would like to participate in discussions about how
-		the Project is run, please join the <a href="http://groups.google.com/group/astropy-dev">
-		Developer Email List [astropy-dev]</a>.
-	</li>
+  <li>If you would like to participate in discussions about how
+  the Project is run, please join the <a href="http://groups.google.com/group/astropy-dev">
+  Developer Email List [astropy-dev]</a>.
+  </li>
 
-	</ul>
+  </ul>
 
-	</section>
+  </section>
 
 
     <section>
@@ -141,10 +141,10 @@
 
 
 
-	<section id="code">
-		<h2 id="contribute-code-or-docs">Contribute code or documentation<a class="paralink" href="#contribute-code-or-docs" title="Permalink to this headline">¶</a></h2>
+  <section id="code">
+  <h2 id="contribute-code-or-docs">Contribute code or documentation<a class="paralink" href="#contribute-code-or-docs" title="Permalink to this headline">¶</a></h2>
 
-		<p>If you are interested in contributing fixes, code or documentation to Astropy (whether the core package or affiliated packages), you should join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> mailing list/forum, and start looking at any related <a href="https://github.com/astropy/astropy/issues">issues</a>. In particular, we have introduced a labeling system used across most Astropy-related packages which will allow you to find good starting issues.  A good label to start with is <a href="https://github.com/search?p=2&q=label%3Apackage-novice&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-package">Package-novice</a> which means you don't need much prior experience of the package. You can use the following links to find all the issues labelled this way and also labeled by how much work they involve:</p>
+  <p>If you are interested in contributing fixes, code or documentation to Astropy (whether the core package or affiliated packages), you should join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> mailing list/forum, and start looking at any related <a href="https://github.com/astropy/astropy/issues">issues</a>. In particular, we have introduced a labeling system used across most Astropy-related packages which will allow you to find good starting issues.  A good label to start with is <a href="https://github.com/search?p=2&q=label%3Apackage-novice&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-package">Package-novice</a> which means you don't need much prior experience of the package. You can use the following links to find all the issues labelled this way and also labeled by how much work they involve:</p>
     <ul>
       <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-low&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-effort">Effort-low</a>: issues that should take a few hours at most
       <li><a href="https://github.com/search?p=2&q=label%3Apackage-novice+label%3Aeffort-medium&ref=searchresults&state=open&type=Issues&utf8=%E2%9C%93" class="github-label-effort">Effort-medium</a>: issues that should take a few days at most
@@ -152,18 +152,18 @@
       </ul>
       <p>You may also want to familiarize yourself with the <a href="http://docs.astropy.org/en/latest/#developer-documentation" target="_blank">developer documentation</a>, particularly the <a href="http://docs.astropy.org/en/latest/development/codeguide.html">coding</a> and <a href="http://docs.astropy.org/en/latest/development/docguide.html">documentation</a> guidelines.</p>
 
-		<p> Once you have a change to propose, if it's a simple fix to just a single file, you can even just browse to the appropriate file and use the "edit" button on github.  If it's a more complex change, we suggest you follow the <a target="_blank" href="https://docs.astropy.org/en/latest/development/workflow/get_devel_version.html">developer install instructions</a>, and use that with <a href="https://github.com/astropy/astropy">Astropy's github page</a> to issue a pull request with your changes.  If you aren't familiar with github, we suggest you looking over our <a href="http://astropy.readthedocs.org/en/latest/development/workflow/development_workflow.html">workflow documentation</a>. Once your code is accepted, you are officially an Astropy contributor and eligible to be included on the author list of future publications.  </p>
+  <p> Once you have a change to propose, if it's a simple fix to just a single file, you can even just browse to the appropriate file and use the "edit" button on github.  If it's a more complex change, we suggest you follow the <a target="_blank" href="https://docs.astropy.org/en/latest/development/workflow/get_devel_version.html">developer install instructions</a>, and use that with <a href="https://github.com/astropy/astropy">Astropy's github page</a> to issue a pull request with your changes.  If you aren't familiar with github, we suggest you looking over our <a href="http://astropy.readthedocs.org/en/latest/development/workflow/development_workflow.html">workflow documentation</a>. Once your code is accepted, you are officially an Astropy contributor and eligible to be included on the author list of future publications.  </p>
 
-		<p> If you want to propose a larger change to Astropy, there's a procedure for that:  <a href="https://github.com/astropy/astropy-APEs">Astropy Proposals for Enhancement (APEs)</a> (modeled after Python's <a href="http://legacy.python.org/dev/peps/">PEPs</a>).  The sort of changes that APEs are intended for include plans for new sub-packages, wide-ranging code re-organizations, a new procedure needing review by a lot of the Astropy community, or an informational document on some decision for Astropy that you want remembered.  For more background on APEs, check out <a href="https://github.com/astropy/astropy-APEs/blob/master/APE1.rst">APE #1</a> and the <a href="https://github.com/astropy/astropy-APEs/blob/master/README.rst">APE repository's README</a>.  There is also a <a href="https://github.com/astropy/astropy/wiki/APE-Overview">wiki page on Astropy's github repository</a> that has an overview of the existing APEs.</p>
+  <p> If you want to propose a larger change to Astropy, there's a procedure for that:  <a href="https://github.com/astropy/astropy-APEs">Astropy Proposals for Enhancement (APEs)</a> (modeled after Python's <a href="http://legacy.python.org/dev/peps/">PEPs</a>).  The sort of changes that APEs are intended for include plans for new sub-packages, wide-ranging code re-organizations, a new procedure needing review by a lot of the Astropy community, or an informational document on some decision for Astropy that you want remembered.  For more background on APEs, check out <a href="https://github.com/astropy/astropy-APEs/blob/master/APE1.rst">APE #1</a> and the <a href="https://github.com/astropy/astropy-APEs/blob/master/README.rst">APE repository's README</a>.  There is also a <a href="https://github.com/astropy/astropy/wiki/APE-Overview">wiki page on Astropy's github repository</a> that has an overview of the existing APEs.</p>
 
 
-	</section>
+  </section>
 
-	<section id="role">
-		<h2 id="formal-project-role">Taking on a formal project role<a class="paralink"
-		href="#formal-project-role" title="Permalink to this headline">¶</a></h2>
+  <section id="role">
+  <h2 id="formal-project-role">Taking on a formal project role<a class="paralink"
+  href="#formal-project-role" title="Permalink to this headline">¶</a></h2>
 
-		<p>
+  <p>
             If you are interested in a higher level of contribution to the project, you can consider taking on one of the formal
             project roles as listed in the <a href="team.html">Astropy Team</a> page.
             </p>
@@ -179,31 +179,31 @@
             For example, being a core sub-package maintainer involves interacting with users and
             responding to bug reports in a timely manner. If you are interested in taking on such a role, you can volunteer
             either on <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a>, by talking to a holder of the
-						role you are interested in, or a coordination commitee member.
+  role you are interested in, or a coordination commitee member.
         </p>
 
-	</section>
+  </section>
 
-	<section id="affiliated">
-		<h2 id="develop-affiliated-package">Develop an affiliated package<a class="paralink" href="#develop-affiliated-package" title="Permalink to this headline">¶</a></h2>
+  <section id="affiliated">
+  <h2 id="develop-affiliated-package">Develop an affiliated package<a class="paralink" href="#develop-affiliated-package" title="Permalink to this headline">¶</a></h2>
 
-		<p>Whether you have an idea for a new Astronomy package, or already have a package that you want to integrate with the Astropy project, you can develop an affiliated package! You'll want to join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> list so you can notify other developers of your intent to develop an affiliated package, and the <a href="https://groups.google.com/forum/#!forum/astropy-affiliated-maintainers">astropy-affiliated-maintainers</a> mailing list to be kept informed of updates to the package template, as well as to have any dicussions related to setting up affiliated packages.  Then you can check out the <a href="affiliated/index.html#affiliated-instructions">affiliated package guidelines</a> and the <a href="http://github.com/astropy/package-template">template for new affiliated packages</a> to get started. We can even create a repository for your affiliated package in the astropy organization on GitHub, if you ask on the mailing list!</p>
-
-
-	</section>
-
-	<section id="donate">
-		<h2 id="contribute-financially">Contribute Financially<a class="paralink" href="#contribute-financially" title="Permalink to this headline">¶</a></h2>
-
-		<p>Donations to Astropy are managed by <a href="https://numfocus.org/">NumFOCUS</a>. For donors in the United States, your gift is tax-deductible to the extent provided by law. As with any donation, you should consult with your tax adviser about your particular tax situation. If you would like to donate to astropy, please see the NumFOCUS contribution page for the Astropy Project:</p>
-
-		<a class="button" href="https://numfocus.salsalabs.org/donate-to-astropy/index.html" target="_blank">Donate to Astropy</a>
+  <p>Whether you have an idea for a new Astronomy package, or already have a package that you want to integrate with the Astropy project, you can develop an affiliated package! You'll want to join the <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a> list so you can notify other developers of your intent to develop an affiliated package, and the <a href="https://groups.google.com/forum/#!forum/astropy-affiliated-maintainers">astropy-affiliated-maintainers</a> mailing list to be kept informed of updates to the package template, as well as to have any dicussions related to setting up affiliated packages.  Then you can check out the <a href="affiliated/index.html#affiliated-instructions">affiliated package guidelines</a> and the <a href="http://github.com/astropy/package-template">template for new affiliated packages</a> to get started. We can even create a repository for your affiliated package in the astropy organization on GitHub, if you ask on the mailing list!</p>
 
 
-	</section>
+  </section>
 
-	<section id="justify">
-		<h2 id="justify-contribution">For academics: How to justify your contribution<a class="paralink" href="#justify-contribution" title="Permalink to this headline">¶</a></h2>
+  <section id="donate">
+  <h2 id="contribute-financially">Contribute Financially<a class="paralink" href="#contribute-financially" title="Permalink to this headline">¶</a></h2>
+
+  <p>Donations to Astropy are managed by <a href="https://numfocus.org/">NumFOCUS</a>. For donors in the United States, your gift is tax-deductible to the extent provided by law. As with any donation, you should consult with your tax adviser about your particular tax situation. If you would like to donate to astropy, please see the NumFOCUS contribution page for the Astropy Project:</p>
+
+  <a class="button" href="https://numfocus.salsalabs.org/donate-to-astropy/index.html" target="_blank">Donate to Astropy</a>
+
+
+  </section>
+
+  <section id="justify">
+  <h2 id="justify-contribution">For academics: How to justify your contribution<a class="paralink" href="#justify-contribution" title="Permalink to this headline">¶</a></h2>
     <p> While in some more technical areas, contributing code is recognized as a
       goal in and of itself, some academic fields have not yet developed a clear
       understanding of the role of code development relative to other more
@@ -213,44 +213,44 @@
       convincing of the value of such contributions.
     </p>
 
-		<p>Contributing to the Astropy Project as a volunteer directly benefits
-		the astronomical research community in tangible ways.  Nevertheless,
-		people employed in academic departments may be asked to justify their
-		time and efforts in terms of direct benefit to their own department or
-		organization.  In this case it is worth highlighting the
-		well-established role of community service in academia, including:
-			<ul>
-				<li>Referring journal papers</li>
-				<li>Reviewing proposals for funding or for an observatory time allocation committee</li>
-				<li>Serving on a conference science organizing committee</li>
-				<li>Serving on an external review committee such as the NASA Senior Review</li>
-			</ul>
-		</p>
+  <p>Contributing to the Astropy Project as a volunteer directly benefits
+  the astronomical research community in tangible ways.  Nevertheless,
+  people employed in academic departments may be asked to justify their
+  time and efforts in terms of direct benefit to their own department or
+  organization.  In this case it is worth highlighting the
+  well-established role of community service in academia, including:
+  <ul>
+  <li>Referring journal papers</li>
+  <li>Reviewing proposals for funding or for an observatory time allocation committee</li>
+  <li>Serving on a conference science organizing committee</li>
+  <li>Serving on an external review committee such as the NASA Senior Review</li>
+  </ul>
+  </p>
 
-		<p>
-			These volunteer duties typically bring no direct benefit to the home
-			department of a researcher, yet they are widely accepted as
-			necessary to the functioning of global research astronomy. We should
-			now add the following to the above list of community service duties:
-			<ul>
-				<li>Contribute to open source software projects that benefit astronomical research</li>
-			</ul>
-		</p>
+  <p>
+  These volunteer duties typically bring no direct benefit to the home
+  department of a researcher, yet they are widely accepted as
+  necessary to the functioning of global research astronomy. We should
+  now add the following to the above list of community service duties:
+  <ul>
+  <li>Contribute to open source software projects that benefit astronomical research</li>
+  </ul>
+  </p>
 
-	</section>
+  </section>
 
-	<footer>
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-		<script src="js/jquery.sidr.min.js"></script>
-		<script src="js/functions.js"></script>
+  <footer>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="js/jquery.sidr.min.js"></script>
+  <script src="js/functions.js"></script>
 
-		<hr>
-		<p>
-		<img style="vertical-align:middle" src="images/astropy_brandmark.png" height=20><span style="vertical-align:middle">
+  <hr>
+  <p>
+  <img style="vertical-align:middle" src="images/astropy_brandmark.png" height=20><span style="vertical-align:middle">
         <a href="code_of_conduct.html"> The Astropy project is committed to fostering an inclusive community</a></span>.
         </p>
 
-	</footer>
+  </footer>
 
 </div>
 

--- a/contribute.html
+++ b/contribute.html
@@ -131,10 +131,7 @@
     information about your operating system and a full Python stack trace; the
     Astropy developers will walk you through obtaining a stack trace if it is
     necessary.<p>
-
-
-
-
+</section>
 
 
 
@@ -161,7 +158,7 @@
 		href="#formal-project-role" title="Permalink to this headline">¶</a></h2>
 
 		<p>
-            AIf you are interested in a higher level of contribution to the project, you can consider taking on one of the formal
+            If you are interested in a higher level of contribution to the project, you can consider taking on one of the formal
             project roles as listed in the <a href="team.html">Astropy Team</a> page.
             </p>
         <p>
@@ -175,8 +172,8 @@
             maintain this involvement going forward and accept the responsibility of having a role.
             For example, being a core sub-package maintainer involves interacting with users and
             responding to bug reports in a timely manner. If you are interested in taking on such a role, you can volunteer
-            either on `astropy-dev` or by talking to a holder of the role you are interested in, or a coordination commitee 
-            member.
+            either on <a href="http://groups.google.com/group/astropy-dev">astropy-dev</a>, by talking to a holder of the
+						role you are interested in, or a coordination commitee member.
         </p>
 
 	</section>
@@ -200,7 +197,15 @@
 	</section>
 
 	<section id="justify">
-		<h2 id="justify-contribution">Justifying your contribution for academics<a class="paralink" href="#justify-contribution" title="Permalink to this headline"></a></h2>
+		<h2 id="justify-contribution">For academics: How to justify your contribution<a class="paralink" href="#justify-contribution" title="Permalink to this headline"></a></h2>
+    <p> While in some more technical areas, contributing code is recognized as a
+      goal in and of itself, some academic fields have not yet developed a clear
+      understanding of the role of code development relative to other more
+      traditional contributions like publication. This sections aims to
+      provide suggestions to academics for how you might justify contributions
+      to the Astropy project if you are in a field or institution that needs
+      convincing of the value of such contributions.
+    </p>
 
 		<p>Contributing to the Astropy Project as a volunteer directly benefits
 		the astronomical research community in tangible ways.  Nevertheless,


### PR DESCRIPTION
Thinking of #416 as the "straw that broke the camel's back", I noticed while reviewing a few consistency issues and recognized that the page has gotten big enough that it could use a sort of table of contents.  So this PR does a general cleanup of the contribute page and adds some quick links to the top.

(You can see it live at http://eteq.github.io/astropy.github.com/contribute.html at the time of this writing)