### PR TITLE
remove ombuds slot from finance committee

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -125,8 +125,7 @@
             "Kelle Cruz",
             "Hans Moritz G\u00fcnther",
             "John Swinbank",
-            "Erik Tollerud",
-            "Unfilled (Ombudsperson)"
+            "Erik Tollerud"
         ],
         "role-head": "Interim finance committee member",
         "responsibilities": {


### PR DESCRIPTION
Following a discussion on Slack about the topic (cc @bsipocz @keflavich @kelle), this PR removes the implicit "slot" on the finance committee for the ombudsperson.

The gist of the justification is that, while the original motivation was that the ombudsperson should be there to be aware of conflict-of-interest, etc issues, some felt it seems odd/problematic in appearance that someone who's supposed to take an arbitrator role is involved in a decision-making body. (I'm not saying who "some" is since I'm not entirely sure who if anyone in the Slack thread actually thought this vs was concerned about the appearance, but if anyone wants to they are welcome to add further details!).  So this change removes that expectation.

Note that this is *not* necessarily meant to say there shouldn't be a 5th person - the number of seats is not firmly established right now - the idea with this PR is purely meant to indicate that there's no need to hold a seat specifically for the ombudsperson.

cc @hamogu and @jdswinbank as other current members of the interim finance committee.