### PR TITLE
MNT: Remove Seifert from roles, remove Crawford from specutils

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -61,7 +61,7 @@
         },
         {
             "name": "specutils",
-            "maintainer": "Nicholas Earl, Adam Ginsburg, Steve Crawford, and Erik Tollerud",
+            "maintainer": "Nicholas Earl, Adam Ginsburg, and Erik Tollerud",
             "stable": false,
             "home_url": "https://specutils.readthedocs.io",
             "repo_url": "https://github.com/astropy/specutils",
@@ -261,7 +261,7 @@
         },
         {
             "name": "ccdproc",
-            "maintainer": "Steven Crawford, Matt Craig, and Michael Seifert <ccdproc@gmail.com>",
+            "maintainer": "Steven Crawford and Matt Craig <ccdproc@gmail.com>",
             "stable": true,
             "home_url": "https://ccdproc.readthedocs.io",
             "repo_url": "https://github.com/astropy/ccdproc",

--- a/roles.json
+++ b/roles.json
@@ -430,8 +430,7 @@
             {
                 "role": "astropy.io.fits",
                 "people": [
-                    "Simon Conseil",
-                    "Michael Seifert"
+                    "Simon Conseil"
                 ]
             },
             {
@@ -459,8 +458,7 @@
             {
                 "role": "astropy.nddata",
                 "people": [
-                    "Matt Craig",
-                    "Michael Seifert"
+                    "Matt Craig"
                 ]
             },
             {
@@ -572,8 +570,7 @@
             {
                 "role": "ccdproc",
                 "people": [
-                    "Matt Craig",
-                    "Michael Seifert"
+                    "Matt Craig"
                 ]
             },
             {


### PR DESCRIPTION
Fix #410 by 

* Removing Seifert from all active roles, as he requested
* Removing Crawford from specutils but keep him in ccdproc, as Matt Craig requested

There is a larger issue of general upkeep of the whole list (https://github.com/astropy/astropy.github.com/issues/410#issuecomment-716564801) but that is out of scope here and not the intent of the original issue I opened.