### PR TITLE
Escape `\`s in BibTeX

### DIFF
--- a/acknowledging.html
+++ b/acknowledging.html
@@ -41,10 +41,10 @@ Bdsk-Url-1 = {https://dx.doi.org/10.1051/0004-6361/201322068}}`;
 
         var bibtex2018 = `@ARTICLE{astropy:2018,
        author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and
-         {Sip{\H{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L. and
+         {Sip{\\H{o}}cz}, B.~M. and {G{\\"u}nther}, H.~M. and {Lim}, P.~L. and
          {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and
          {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and {Vand
-        erPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-Su{\'a}rez}, D. and
+        erPlas}, J.~T. and {Bradley}, L.~D. and {P{\\'e}rez-Su{\\'a}rez}, D. and
          {de Val-Borro}, M. and {Aldcroft}, T.~L. and {Cruz}, K.~L. and
          {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Ardelean}, C. and
          {Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and
@@ -52,17 +52,17 @@ Bdsk-Url-1 = {https://dx.doi.org/10.1051/0004-6361/201322068}}`;
          {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and
          {Bostroem}, K.~A. and {Bouma}, L.~G. and {Brammer}, G.~B. and
          {Bray}, E.~M. and {Breytenbach}, H. and {Buddelmeijer}, H. and
-         {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\'\i}guez}, J.~L. and
+         {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\\'\\i}guez}, J.~L. and
          {Cara}, M. and {Cardoso}, J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and
          {Corrales}, L. and {Crichton}, D. and {D'Avella}, D. and {Deil}, C. and
-         {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and
+         {Depagne}, {\\'E}. and {Dietrich}, J.~P. and {Donath}, A. and
          {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and
          {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and
          {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and
          {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and
          {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and
          {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and
-         {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and
+         {Hunkeler}, J.~S. and {Ivezi{\\'c}}, {\\v{Z}}. and {Jain}, A. and
          {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern}, N.~S. and
          {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J. and {Kirkby}, D. and
          {Kulkarni}, A.~M. and {Kumar}, A. and {Lee}, A. and {Lenz}, D. and
@@ -70,7 +70,7 @@ Bdsk-Url-1 = {https://dx.doi.org/10.1051/0004-6361/201322068}}`;
          {Mastropietro}, M. and {McCully}, C. and {Montagnac}, S. and
          {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and {Muna}, D. and
          {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and
-         {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and
+         {Ninan}, J.~P. and {N{\\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and
          {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and
          {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and
          {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and
@@ -79,12 +79,12 @@ Bdsk-Url-1 = {https://dx.doi.org/10.1051/0004-6361/201322068}}`;
          {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and
          {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and
          {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and
-         {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and
+         {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\\'o}n}, V. and
          {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and
          {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and
          {Zabalza}, V. and {Astropy Contributors}},
         title = "{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}",
-      journal = {\aj},
+      journal = {\\aj},
      keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
          year = 2018,
         month = sep,


### PR DESCRIPTION
The BibTeX generated by the big orange button at https://www.astropy.org/acknowledging.html currently doesn't work, because all the `\`s are swallowed by Javascript. This escapes them, so they aren't.