### PR TITLE
Add Leo Singer to astropy-healpix maintainers

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -557,7 +557,8 @@
             {
                 "role": "astropy-healpix",
                 "people": [
-                    "Thomas Robitaille"
+                    "Thomas Robitaille",
+                    "Leo Singer"
                 ]
             },
             {


### PR DESCRIPTION
@lpsinger is the biggest contributor to astropy-healpix at the moment and familiar with the astropy workflow/guidelines - he has indicated that he is happy to co-maintain astropy-healpix.