### PR TITLE
update voting members following Jul 2021 election

### DIFF
--- a/team.html
+++ b/team.html
@@ -135,6 +135,7 @@
       <li>Tom Aldcroft</li>
       <li>Larry Bradley</li>
       <li>Clara Brasseur</li>
+      <li>Michael K. Brewer</li>
       <li>E. Madison Bray</li>
       <li>Juan Luis Cano Rodríguez</li>
       <li>Mihai Cara</li>
@@ -143,32 +144,41 @@
       <li>Matt Craig</li>
       <li>Kelle Cruz</li>
       <li>Nadia Dencheva</li>
+      <li>Michael Droettboom</li>
       <li>Nicholas Earl</li>
       <li>Tom Donaldson</li>
+      <li>Wilfred Gee</li>
       <li>Adam Ginsburg</li>
       <li>Lauren Glattly</li>
       <li>Perry Greenfield</li>
       <li>Moritz Günther</li>
       <li>Derek Homeier</li>
       <li>Pey Lian Lim</li>
+      <li>Stuart Littlefair</li>
       <li>Brett Morris</li>
       <li>Stuart Mumford</li>
+      <li>Aarya Patil</li>
       <li>Adrian Price-Whelan</li>
       <li>Thomas Robitaille</li>
+      <li>Albert Y. Shih</li>
       <li>David Shupe</li>
       <li>Jonathan Sick</li>
       <li>Leo Singer</li>
       <li>Brigitta Sipőcz</li>
       <li>Edward Slavich</li>
+      <li>Nathaniel Starkman</li>
       <li>Ole Streicher</li>
       <li>John Swinbank</li>
       <li>Erik Tollerud</li>
+      <li>James Turner</li>
       <li>Marten van Kerkwijk</li>
+      <li>Zé Vinícius</li>
     </ul>
 
     <h3 id="votingmembers-emeritus">Emeritus Voting Members<a class="paralink" href="#votingmembers-emeritus" title="Permalink to this headline">¶</a></h3>
     <ul class="team">
       <li>Steve Crawford</li>
+      <li>Michael Seifert</li>
     </ul>
     </p>
 


### PR DESCRIPTION
This PR updates the list of voting members to reflect the results of the initial voting members election.

cc @ceb8 @mwcraig @Cadair 