### PR TITLE
Add a new top-level credits page

### DIFF
--- a/about.html
+++ b/about.html
@@ -60,6 +60,7 @@
                 </li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
 				<li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
 
 			</ul>
 		</div>

--- a/acknowledging.html
+++ b/acknowledging.html
@@ -150,6 +150,7 @@ archivePrefix = {arXiv},
 				</li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
                 <li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
 
 			</ul>		</div>
 		<div class="search pull-right">

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -60,6 +60,7 @@
 				</li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
                 <li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
 			</ul>
 		</div>
 		<div class="search pull-right">

--- a/contribute.html
+++ b/contribute.html
@@ -58,6 +58,7 @@
   </li>
   <li><a href="affiliated/index.html">Affiliated Packages</a></li>
                 <li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
   </ul>
   </div>
   <div class="search pull-right">

--- a/credits.html
+++ b/credits.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="description" content="Astropy. A Community Python Library for Astronomy." />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="shortcut icon" href="favicon.ico" />
+
+<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css' />
+<link rel="stylesheet" type="text/css" href="css/style.css" />
+<link rel="stylesheet" type="text/css" href="css/jquery.sidr.light.css" />
+
+<style>
+   table.roles td {word-break:normal}
+</style>
+
+<title>Astropy Credits</title>
+
+<!-- Google analytics -->
+<script src="js/analytics.js"></script>
+</head>
+
+<body>
+
+<div id="wrapper">
+	<nav>
+		<div id="mobile-header">
+			<!-- Menu Icon -->
+		    <a id="responsive-menu-button" href="#sidr-main"><div><svg senable-background="new 0 0 24 24" height="24px" id="Layer_1" version="1.1" viewBox="0 0 24 24" width="24px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g><g><path d="M23.244,17.009H0.75c-0.413,0-0.75,0.36-0.75,0.801v3.421C0,21.654,0.337,22,0.75,22h22.494c0.414,0,0.75-0.346,0.75-0.77    V17.81C23.994,17.369,23.658,17.009,23.244,17.009z M23.244,9.009H0.75C0.337,9.009,0,9.369,0,9.81v3.421    c0,0.424,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.345,0.75-0.769V9.81C23.994,9.369,23.658,9.009,23.244,9.009z     M23.244,1.009H0.75C0.337,1.009,0,1.369,0,1.81V5.23c0,0.423,0.337,0.769,0.75,0.769h22.494c0.414,0,0.75-0.346,0.75-0.769V1.81    C23.994,1.369,23.658,1.009,23.244,1.009z"/></g></g></svg></div></a>
+		    <!-- -->
+		</div>
+		<a href="index.html"><img src="images/astropy_word.svg" height="32" onerror="this.src='images/astropy_word_32.png; this.onerror=null;"/></a>
+		<div id="navigation">
+<ul>
+		    <li>
+                <div class="dropdown">
+                  <a>About</a>
+                  <div class="dropdown-content">
+                    <ul>
+                    <li><a href="about.html">About Astropy</a></li>
+                    <li><a href="code_of_conduct.html">Code of Conduct</a></li>
+                    <li><a href="acknowledging.html">Acknowledging & Citing</a></li>
+                    </ul>
+                  </div>
+                </div>
+			    </li>
+				<li><a href="help.html">Get Help</a></li>
+				<li><a href="contribute.html">Contribute</a></li>
+				<li>
+                    <div class="dropdown">
+                        <a href="http://docs.astropy.org">Documentation</a>
+                        <div class="dropdown-content">
+                            <ul>
+                                <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
+                                <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </li>
+				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
+                <li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
+			</ul>
+		</div>
+		<div class="search pull-right">
+			<form action="http://docs.astropy.org/en/stable/search.html" method="get">
+			  <input type="text" name="q" placeholder="Search Documentation" />
+			  <input type="hidden" name="check_keywords" value="yes" />
+			  <input type="hidden" name="area" value="default" />
+			</form>
+		</div>
+	</nav>
+
+    <section>
+    <h1 id="astropy-credits">Astropy Credits<a class="paralink"
+    href="#astropy-credits" title="Permalink to this headline">¶</a></h1>
+
+    <p>The Astropy Project is made possible through the hard work of hundreds of
+    people in the community. Contributions take many forms, from participating
+    in online forums, being an Astropy sub-committee member, giving talks,
+    writing tutorials and documentation, writing code, making releases,
+    organizing conferences, and much much more.</p>
+
+    <p>In this page we specially recognize the people and organizations that
+    have made significant contributions to the Astropy project. This comes in
+    the form of <a href="#lifetime-credits">lifetime contributors</a> and <a
+    href="#institutional-support">institutional support</a> that provides both
+    direct and indirect funding for Astropy.
+
+    </p>
+
+
+</section>
+
+<section>
+<h1 id="lifetime-credits">Lifetime Contributors<a class="paralink"
+href="#lifetime-credits" title="Permalink to this headline">¶</a></h1>
+
+    <p>Here we list individuals who estimate they have spent 2000 hours or more,
+    equivalent to full time for a year, working on and contributing to the
+    Astropy Project. These individuals have demonstrated a long-term commitment
+    to the project in many areas and exemplify the high standards we seek to
+    achieve.
+    </p>
+
+    <h3>Adrian Price-Whelan</h3>
+    Adrian is the lead coordinator and developer behind the Learn Astropy and
+    Astropy tutorials initiatives. He was an initial contributor of the concept
+    and code for the Quantity class in astropy.units and serves as lead
+    developer of astropy.coordinates. In the latter role he played a key role in
+    adding support for velocity data such as proper motions in
+    astropy.coordinates.
+
+    <h3>Brigitta Sipőcz</h3>
+    Since coming to the project as a Google Summer of Code (GSoC) student in
+    2014, Brigitta has been an active and valued member of the Astropy community
+    in many key roles. Most notably, she has developed and maintains
+    responsibility for critical parts of the Astropy infrastructure which keep
+    the core package and affiliated packages running smoothly for both testing
+    and release distribution. She serves as an astropy core release manager and
+    serves as the GSoC coordinator for Astropy.
+
+    <h3>Erik Tollerud</h3>
+    Erik has played a key leadership and technical role in the Astropy project
+    since it began in 2011. His individual contributions are too numerous to
+    name, but they include contributing large parts of the core coordinates and
+    uncertainties packages, serving in the Coordination Committee since 2011,
+    serving as a release manager and a number of infrastructure roles, providing
+    leadership on writing the Astropy papers and proposals, and Finance
+    committee work.
+
+    <h3>Kelle Cruz</h3>
+    Kelle has served on the Coordination Committee since 2016 with a focus on
+    community management, user discussion forums, workshops, and expanding
+    educational materials. Her role as the Learn Coordinator has been especially
+    impacting. She has played a crucial lead role in the areas of governance,
+    fundraising, and grant writing as Astropy has grown into a large and widely
+    recognized project.
+
+    <h3>Larry Bradley</h3>
+    Larry has served as the lead developer and maintainer of the Photutils
+    package (an Astropy coordinated package for source detection and photometry)
+    since 2014. He also serves as a maintainer of the astropy regions package
+    and the astropy visualization, stats, and convolution subpackages.
+
+    <h3>Madison Bray</h3>
+    Madison was a founding member of the Astropy project and was the main
+    developer of the io.fits core subpackage which forms the basis of much of
+    the I/O for astropy. After taking a hiatus from Astropy in 2016 for another
+    opportunity, Madison rejoined in the role of DevOps and Operations Support
+    in 2020.
+
+    <h3>Marten van Kerkwijk</h3>
+    Marten has been actively involved in astropy core development since 2013. He
+    has made many key contributions, most notably leading the effort to make
+    Quantities truly useful throughout astropy by making interaction with numpy
+    functions seamless and ensuring they work well inside coordinates. He led
+    the development of algorithm improvements in the Time class to ensure
+    accuracy at the level needed for pulsar timing, and he played an important
+    role in making the Table class versatile.
+
+    <h3>Michael Droettboom</h3>
+    Michael was a prolific contributor to Astropy from 2011 through 2015,
+    contributing over 400 pull requests in many areas of the core, with a focus
+    on the wcs, votable, and table subpackages. His deep understanding of best
+    coding practices provided important inspiration for other members of the
+    initial core development team.
+
+    <h3>Moritz Guenther</h3>
+    Moritz has been involved in the Project since 2011, with contributions to
+    the io.ascii package and a continuing role as a package maintainer. He has
+    also contributed to the stats core subpackage and the photutils and saba
+    packages. Since 2020, Moritz has been serving as an Affiliated Package
+    review editor and has been an active member of the interim Finance Committee
+
+    <h3>Nadia Dencheva</h3>
+    Nadia has been an active member of the Pproject since it started, where she
+    has been the lead developer and maintainer for the modeling and wcs
+    packages. She has also been involved with the serialization of astropy
+    objects to the ASDF format.
+
+    <h3>Perry Greenfield</h3>
+    More than any other single person, Perry has been responsible for the
+    adoption of Python in astronomy. He recognized the promise of Python as a
+    language for astronomical data analysis and processing far before the rest
+    of the community and was responsible for an institutional commitment of
+    substantial resources in this direction. Perry was a key player in the
+    initial formation of the Astropy project and served as a Coordination
+    Committee member from 2011 to 2016. In 2020, Perry took on the role of
+    Ombudsperson.
+
+    <h3>Pey Lian Lim</h3>
+    Pey Lian has been an important team member since 2012, providing key
+    infrastructure and operational support focused on the core package. In her
+    maintainer roles for testing and documentation infrastructure and DevOps and
+    Operations Support, she keeps Astropy running. Special commendation is due
+    for leading the extremely rapid and unexpected migration from Travis CI to
+    GitHub Actions in 2020. Pey Lian's tireless attention in triaging core
+    issues is well-recognized.
+
+    <h3>Simon Conseil</h3>
+    After a first pull request in 2012, Simon became a regular contributor to
+    Astropy around 2015. Since 2017 he has been the main maintainer of io.fits,
+    taking on the daunting role of managing this complex and critical
+    subpackage. He also contributes other parts of Astropy including
+    infrastructure, modeling, io.ascii, stats, table, and visualization.
+
+    <h3>Tom Aldcroft</h3>
+    In 2011, Tom was part of an initial core group that recognized the need for
+    a common Astropy package for the community, and he helped organize the first
+    official Astropy coordination meeting. Since that time he has been an active
+    contributor to the project, taking a lead role in the development and
+    maintenance of three core subpackages: table, time, and io.ascii. In 2016 he
+    was appointed as one of the Astropy Project Coordination Committee members.
+
+    <h3>Tom Robitaille</h3>
+    Tom has been a recognized leader in the Astropy project since it began,
+    being part of the core group that started the project and organized the
+    first Astropy coordination meeting. His individual contributions are too
+    numerous to name, but they include contributing large parts of the core
+    package covering many areas, developing the astropy-healpix and regions
+    coordinated packages, serving as a release manager, GSoC coordinator, and
+    member of the Coordination Committee.
+
+<section>
+
+<h1 id="institutional-support">Institutional Support<a class="paralink"
+href="#institutional-support" title="Permalink to this headline">¶</a></h1>
+
+Here we recognize the institutions who have made major contributions to the
+Astropy project by either direct funding to the project or by indirect funding
+of employees who have contributed.
+
+<h3>Space Telescope Science Institute (STScI)</h3>
+STScI has played a foundational role in the development and advancement of the
+Astropy Project since its inception. STScI has provided continued and
+substantial support to the project via staff contributions since 2011, including
+X lifetime contributors to astropy.  Additionally, STScI has provided on-going
+support and leadership to both Astropy and the  broader scientific Python
+computing ecosystem.
+
+<h3>Moore Foundation</h3>
+In late 2019 the Astropy project was awarded a major grant from the Gordon and
+Betty Moore Foundation. This grant was targeted at supporting Astropy’s
+transition to a fully sustainable project, where success no longer hinges on a
+limited set of contributors. This grant was transformative for the Project.
+
+<h3>Chandra X-ray Center (CXC)</h3>
+The CXC has supported multiple staff members to work on the Astropy project,
+equivalent to   more than 5 person-years since the start of the project.
+
+<h3>NumFocus</h3>
+We wish to express gratitude to the NumFocus Organization for providing the
+organizational support to grow Astropy into the role of a community-leading
+project with a substantial budget.
+
+<h3>Center for Computational Astronomy (CCA), Flatiron Institute, Simons
+Foundation</h3>
+The CCA has provided logistical and travel support for the Python in Astronomy
+conference, the coordination meeting (dates), and the spectroscopy working
+group.
+
+		<p>
+		<img style="vertical-align:middle" src="images/astropy_brandmark.png" height=20><span style="vertical-align:middle">
+        <a href="code_of_conduct.html"> The Astropy project is committed to fostering an inclusive community</a></span>.
+        </p>
+
+	</footer>
+
+</div>
+
+</body>
+</html>

--- a/help.html
+++ b/help.html
@@ -57,6 +57,7 @@
 				</li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
                 <li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
 			</ul>
 		</div>
 		<div class="search pull-right">

--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@ window.onload = function() {
 				</li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
 				<li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
 			</ul>
 		</div>
 		<div class="search pull-right">

--- a/team.html
+++ b/team.html
@@ -60,6 +60,7 @@
                 </li>
 				<li><a href="affiliated/index.html">Affiliated Packages</a></li>
                 <li><a href="team.html">Team</a></li>
+                <li><a href="credits.html">Credits</a></li>
 			</ul>
 		</div>
 		<div class="search pull-right">


### PR DESCRIPTION
This makes a new top-level Astropy Credits page including:
- Lifetime Contributors
- Institutional Support

This addresses https://github.com/astropy/astropy-project/issues/135 and the original discussion on astropy-dev "Proposal for giving credit for contributions" from May 2020.

The list of lifetime contributors was based on self-reported status in the last roles survey along with known "alumni" that are not currently active.

This does not include the credits listing for people who have made substantial contributions (at the 2,4,8,16 hrs per week level) in the last year that has been discussed previously. That is still planned but has been taken out of this PR to address some implementation concerns that came up in CoCo discussions.

Cc-ing folks that have participated in past discussions:
@eteq @mhvk @hamogu @astrofrog @kelle