### PR TITLE
Remove Adrian from roles, add Jonathan Sick to tutorials infrastructure team

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -166,7 +166,8 @@
                 "role": "Infrastructure",
                 "people": [
                     "Adrian Price-Whelan",
-                    "Erik Tollerud"
+                    "Erik Tollerud",
+                    "Jonathan Sick"
                 ]
             },
             {

--- a/roles.json
+++ b/roles.json
@@ -75,7 +75,6 @@
                 "role": "Conferences",
                 "people": [
                     "Kelle Cruz",
-                    "Adrian Price-Whelan",
                     "Erik Tollerud"
                 ]
             }
@@ -312,7 +311,6 @@
         "people": [
             "Larry Bradley",
             "Stuart Mumford",
-            "Adrian Price-Whelan",
             "Thomas Robitaille",
             "Brigitta Sip\u0151cz"
         ],


### PR DESCRIPTION
- I no longer have time to help with conference coordination
- I haven't worked on package template maintenance in too long, and won't have time to re-engage, so removing myself from that role as well.
- I added Jonathan Sick (@jonathansick) because he has been hired to work on infrastructure for the astropy tutorials.