### PR TITLE
Limit scope of affiliated packages

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -218,7 +218,10 @@
 		<li>Be potentially useful to astronomers.  This can mean useful to a
 		specific sub-domain of astronomy, or more broadly useful to a large
 		fraction of astronomy (or beyond, as long as it is also useful for
-		astronomy).
+		  astronomy).</li>
+
+		<li>Specifically use, interface with, or provide complimentary capabilities
+		  to other Astropy pacakges.</li>
 
 		<li>Be written in a way that is readable and understandable by others. While
 		not a strict requirement, we also provide <a

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -220,7 +220,7 @@
 		fraction of astronomy (or beyond, as long as it is also useful for
 		astronomy).</li>
 
-		<li>Specifically use, interface with, or provide complimentary capabilities
+		<li>Specifically use, interface with, or provide complementary capabilities
 		  to other Astropy packages.</li>
 
 		<li>Be written in a way that is readable and understandable by others. While

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -218,10 +218,10 @@
 		<li>Be potentially useful to astronomers.  This can mean useful to a
 		specific sub-domain of astronomy, or more broadly useful to a large
 		fraction of astronomy (or beyond, as long as it is also useful for
-		  astronomy).</li>
+		astronomy).</li>
 
 		<li>Specifically use, interface with, or provide complimentary capabilities
-		  to other Astropy pacakges.</li>
+		  to other Astropy packages.</li>
 
 		<li>Be written in a way that is readable and understandable by others. While
 		not a strict requirement, we also provide <a


### PR DESCRIPTION
This PR adds a bullet point to clarify that affiliated packages should
be in some way related to other astropy packages or functionality,
not just be any package that might be useful for astronomers.
(E.g., we don't want to make numpy an affiliated package, nor django,
just because astronomers can also build websites).