### PR TITLE
Add Stuart Mumford as discourse maintainer

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -90,7 +90,7 @@
                 "Maintain the @astropy twitter account",
                 "Monitor/moderate the Python Users in Astronomy Facebook group",
                 "Keep track of/help organize conferences and workshops",
-		"Maintain infrastructure for a specific channel (e.g. discourse)"
+	  	"Maintain infrastructure for a specific channel (e.g., discourse)"
             ]
         }
     },


### PR DESCRIPTION
@Cadair did set up the discourse forum and has done the technical side of maintaining it. This role is not meant to make him the lone and all-powerful and all-responsible editor but rather to list him in the roles pages so that people know whom to thank for setting it up and whom to contact if they are absolutely stuck (within discourse, there is an FAQ and a "Have a question" category so that @Cadair is not the only contact point). Discussion on the development of discourse (e.g. if new categories are needed) will likely happen within discourse by the community, that's beyond the scope of this specific role.

CC: @Cadair Happy with this description? I don't see a place to put it all in the roles.json, but I wanted to at least record it in the PR.
