### PR TITLE
fix links to point to newer versions of affiliate instructions

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -205,10 +205,10 @@
 
 	<p>If you are a developer of an astronomy package and would like your package
 	to become affiliated with the Astropy Project, please take a look at the
-	<a href="https://github.com/astropy/astropy-procedures/blob/main/documents/affiliated_package_review_process.md#proposing-an-affiliated-package">
+	<a href="https://github.com/astropy/astropy-project/blob/main/affiliated/affiliated_package_review_process.md#proposing-an-affiliated-package">
   instructions for proposing an affiliated package</a>. We recommend that you
 	also take a look at the
-	<a href="https://github.com/astropy/astropy-procedures/blob/main/documents/affiliated_package_review_guidelines.md">
+	<a href="https://github.com/astropy/astropy-project/blob/main/affiliated/affiliated_package_review_guidelines.md">
 	guidelines for reviewing affiliated packages</a> since this will give you a
 	sense of whether your package is ready for review. Broadly speaking, your
 	package should:</p>


### PR DESCRIPTION
just what it says on the tin... just a couple of out-of-date links.