### PR TITLE
Remove link to “documentation overview”

### DIFF
--- a/about.html
+++ b/about.html
@@ -97,11 +97,9 @@
     wishes to contribute to the project and expect everyone in our community
     to follow the <a href="code_of_conduct.html">code of conduct</a> when interacting with others.</p>
 
-    <p>For more details on the plan for the project, you can read the
-	<a href="http://docs.astropy.org/en/stable/overview.html">documentation overview</a>,
-	or the
-	<a href="http://docs.astropy.org/en/stable/development/vision.html">original vision</a>
-	from when the project was founded. </p>
+    <p>For more details on background of the project, you can read the
+    <a href="http://docs.astropy.org/en/stable/development/vision.html">original vision</a>
+    from when the project was founded.</p>
     </section>
 
     <section>


### PR DESCRIPTION
That page says “This page has been removed. For an overview, see the
http://www.astropy.org page”, and has done since at least v2.0.16
(https://docs.astropy.org/en/v2.0.16/overview.html).