### PR TITLE
Replace Moritz with Aarya on the finance committee

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -129,7 +129,7 @@
         "url": "finance_committee_member",
         "people": [
             "Kelle Cruz",
-            "Hans Moritz G\u00fcnther",
+            "Aarya Patil",
             "John Swinbank",
             "Erik Tollerud"
         ],


### PR DESCRIPTION
Moritz has said in this nomination for the Coco, that he would step back
from other Astropy roles if elected. Based on nominations from the community,
the Coco has contacted Aarya, who is interested in joining the finance
committee.
This PR will stay open for two weeks for any discussion.