### PR TITLE
Make Derek affiliated package editor

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -224,7 +224,7 @@
     {
         "role": "Affiliated package review editor",
         "url": "Affiliated_package_review_editor",
-        "people": ["Hans Moritz G\u00fcnther", "Pey Lian Lim"],
+        "people": ["Derek Homeier", "Pey Lian Lim"],
         "deputy": ["Unfilled"],
         "role-head": "Affiliated package review editor",
         "responsibilities": {


### PR DESCRIPTION
Based on nominations from the community, the Coco has reached out to Derek to
nominate him as affilated package editor to replace Moritz, who wants to step
back from other astropy roles to make time for Coco work.