### PR TITLE
Remove astropy-helpers role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -260,25 +260,6 @@
         }
     },
     {
-        "role": "Astropy-helpers maintainer",
-        "url": "Astropyhelpers_maintainer",
-        "people": [
-            "Stuart Mumford",
-            "Brigitta Sip\u0151cz",
-            "Erik Tollerud"
-        ],
-        "role-head": "Astropy-helpers maintainer",
-        "responsibilities": {
-            "description": "Lead the development and maintenance of the astropy-helpers repository, including:",
-            "details": [
-                "Managing issues/pull requests for the astropy-helpers repository",
-                "Assisting the core package release coordinator, including performing (or helping perform) the release process for astropy-helpers during core package releases",
-                "Performing any necessary incremental/bugfix releases between Astropy releases",
-                "Communicating to affiliated package maintainers the availability of new versions of astropy-helpers, and assist in updating in cases where changes are not trivial"
-            ]
-        }
-    },
-    {
         "role": "DevOps and Operations Specialist",
         "url": "devops_team",
         "people": [


### PR DESCRIPTION
astropy-helpers has been replaced following APE17. The APE was accepted at the end of 2019 and astropy-helpers has be deprecated for a year now (see https://github.com/astropy/astropy-helpers/blob/master/README.rst ). The last commit was in March 2021, just to make the deprecation message bigger. So it seems that this is not an active role any longer and thus can be removed from the astropy.org/team page.

CC: @Cadair (I tagged the other two currently listed astropy-helpers maintainers for review, but I can't do that for @Cadair in this repro, so mention him by text here).