### PR TITLE
Update Omnifit package status

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -525,16 +525,16 @@
             "repo_url": "https://github.com/RiceMunk/omnifit",
             "pypi_name": "omnifit",
             "image": null,
-            "description": "Python library intended to help with the analysis of astronomical spectra for signs of interstellar ices.",
+            "description": "Package for doing astronomical spectroscopy fitting of interstellar ices.",
             "coordinated": false,
             "review": {
                 "functionality": "Specialized package",
                 "ecointegration": "Partial",
                 "documentation": "Partial",
-                "testing": "Partial",
+                "testing": "Good",
                 "devstatus": "Functional but low activity",
-                "python3": "No",
-                "last-updated": "2017-11-08"
+                "python3": "Yes",
+                "last-updated": "2021-01-12"
             }
         },
         {


### PR DESCRIPTION
With RiceMunk/omnifit#43 this package is now fully supporting Python 3.7-3.10 pip-installs and passing all tests against Astropy 5.0. I have also upgraded the `testing` level to `Good`, since there are CI tests for Linux, macOS and Windows with coverage of 85-100% (with the exception of `utils`).