### PR TITLE
Show latest core package version from PyPI

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
 <!-- Meow woof -->
 <script>
 window.onload = function() {
+
+  $.getJSON('https://pypi.org/pypi/astropy/json', function(data) {
+	document.getElementById('core-package-version').innerHTML = 'Current Version: ' + data.info.version;
+  });
+
+
   var today = new Date();
   var month = today.getMonth() + 1;
   var date = today.getDate();
@@ -35,6 +41,7 @@ window.onload = function() {
     dogeImg.src = 'images/astropy_doge.png';
     dogeImg.alt = 'wow so open very python';
   }
+
 };
 </script>
 
@@ -104,7 +111,7 @@ window.onload = function() {
 
 <section class="whatsnew"><div id="prenew"></div>
 	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/5.0.html">Astropy 5.0?</a>
-	<p class="version">Current Version: 5.0.1</p>
+	<p class="version" id="core-package-version"></p>
 
 </section>
 


### PR DESCRIPTION
This uses JS code adapted from

https://github.com/sunpy/sunpy-sphinx-theme/blob/main/sunpy_sphinx_theme/sunpy/static/version.js

to get the latest version from PyPI which will save having to update it during releases. This is an alternative to https://github.com/astropy/astropy.github.com/pull/406 and the advantage here is we maintain the same formatting as before.

@Cadair - do you want us to include the sunpy license or is this trivial enough to life without attribution? (either way is fine!)