### PR TITLE
Invite applications or nomination for all roles

### DIFF
--- a/team.html
+++ b/team.html
@@ -93,7 +93,7 @@
 					or want to suggest another person for any of the roles below to email
                     <a href="mailto:coordinators@astropy.org">coordinators@astropy.org</a>.
 					We are looking for volunteers both for roles currently unfilled or in 
-					addition the current team.
+					addition to the current team.
                 </p>
 
                 <table id="astropy-roles">

--- a/team.html
+++ b/team.html
@@ -94,6 +94,10 @@
                     <a href="mailto:coordinators@astropy.org">coordinators@astropy.org</a>.
 					We are looking for volunteers both for roles currently unfilled or in 
 					addition to the current team.
+                <p> We are always looking for interested community members to fill empty roles and to join existing
+                        teams. Community members may volunteer or nominate someone else for any role by emailing 
+                        <a href="mailto:coordinators@astropy.org">coordinators@astropy.org</a> or by getting in 
+                        touch with the current team.
                 </p>
 
                 <table id="astropy-roles">

--- a/team.html
+++ b/team.html
@@ -89,10 +89,11 @@
 		responsibilities</a> section below for a full description of each
 		role.
 
-                <p>Some roles are currently unfilled and we
-                invite community members with an interest to inquire about
-                volunteering by emailing to
-                <a href="mailto:coordinators@astropy.org">coordinators@astropy.org</a>.
+                <p> We invite community members who are willing to volunteer themselves
+					or want to suggest another person for any of the roles below to email
+                    <a href="mailto:coordinators@astropy.org">coordinators@astropy.org</a>.
+					We are looking for volunteers both for roles currently unfilled or in 
+					addition the current team.
                 </p>
 
                 <table id="astropy-roles">

--- a/team.html
+++ b/team.html
@@ -89,11 +89,6 @@
 		responsibilities</a> section below for a full description of each
 		role.
 
-                <p> We invite community members who are willing to volunteer themselves
-					or want to suggest another person for any of the roles below to email
-                    <a href="mailto:coordinators@astropy.org">coordinators@astropy.org</a>.
-					We are looking for volunteers both for roles currently unfilled or in 
-					addition to the current team.
                 <p> We are always looking for interested community members to fill empty roles and to join existing
                         teams. Community members may volunteer or nominate someone else for any role by emailing 
                         <a href="mailto:coordinators@astropy.org">coordinators@astropy.org</a> or by getting in 


### PR DESCRIPTION
The previous wording only asked for volunteers for currenty unfilled roles, but there are many roles where additional help would be useful, even if they are not currently unfilled.