### PR TITLE
Add kanon to affiliated packages

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1048,6 +1048,24 @@
                 "python3": "Yes",
                 "last-updated": "2020-07-13"
             }
+        },
+        {
+            "name": "kanon",
+            "maintainer": "Léni Gauffier <lenigauffier@gmail.com>",
+            "stable": true,
+            "home_url": "https://kanon.readthedocs.io/",
+            "repo_url": "https://github.com/legau/kanon",
+            "pypi_name": "kanon",
+            "description": "History of astronomy package, historical geocentric models and number systems",
+            "review": {
+                 "functionality": "To be filled out by the reviewer",
+                 "ecointegration": "To be filled out by the reviewer",
+                 "documentation": "To be filled out by the reviewer",
+                 "testing": "To be filled out by the reviewer",
+                 "devstatus": "To be filled out by the reviewer",
+                 "python3": "To be filled out by the reviewer",
+                 "last-updated": "To be filled out by the reviewer"
+            }
         }
     ]
 }

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1057,6 +1057,7 @@
             "repo_url": "https://github.com/legau/kanon",
             "pypi_name": "kanon",
             "description": "History of astronomy package, historical geocentric models and number systems",
+            "coordinated": false,
             "review": {
                  "functionality": "Specialized package",
                  "ecointegration": "Good",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1058,13 +1058,13 @@
             "pypi_name": "kanon",
             "description": "History of astronomy package, historical geocentric models and number systems",
             "review": {
-                 "functionality": "To be filled out by the reviewer",
-                 "ecointegration": "To be filled out by the reviewer",
-                 "documentation": "To be filled out by the reviewer",
-                 "testing": "To be filled out by the reviewer",
-                 "devstatus": "To be filled out by the reviewer",
-                 "python3": "To be filled out by the reviewer",
-                 "last-updated": "To be filled out by the reviewer"
+                 "functionality": "Specialized package",
+                 "ecointegration": "Good",
+                 "documentation": "Partial",
+                 "testing": "Good",
+                 "devstatus": "Good",
+                 "python3": "Yes",
+                 "last-updated": "2022-02-05"
             }
         }
     ]


### PR DESCRIPTION
Kanon is a package for modeling ancient astronomical models from tables and mathematical models. It uses astropy for interoperability with modern astronomy tools.

It is a really specialized package but an interesting addition.