### PR TITLE
Add general maintainers role for astropy core package

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -407,6 +407,7 @@
                 "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem, in particular for pull requests spanning multiple sub-packages",
                 "Merging Pull Requests that are non-controversial or after reaching out to relevant subpackage maintainers",
                 "Maintain, review, and advocate for useful interaction between multiple sub-packages", 
+                "Perform initial triaging of issues and pull requests",
                 "Keeping track of frequent contributors and their relevant areas of expertise"
             ]
         }
@@ -565,6 +566,7 @@
                 "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem",
                 "Merging Pull Requests in the sub-package",
                 "Keeping track of the \u201cbig picture\u201d progress of the sub-package - includes new feature development and significant bugs",
+                "Perform initial triaging of issues and pull requests",
                 "Keeping track of frequent contributors to the sub-package and their relevant areas of expertise"
             ]
         }

--- a/roles.json
+++ b/roles.json
@@ -395,7 +395,24 @@
         }
     },
     {
-        "role": "Sub-package maintainer",
+        "role": "Core astropy package maintainer (general)",
+        "url": "Core_package_general_maintainer",
+        "people": [
+            "unfilled"
+        ],
+        "role-head": "Core astropy package maintainer (general)",
+        "responsibilities": {
+            "description": "Maintain the astropy core package in aspects that are not specific to a single sub-package",
+            "details": [
+                "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem, in particular for pull requests spanning multiple sub-packages",
+                "Merging Pull Requests",
+                "Maintain, review, and advocate for useful interaction between multiple sub-packages", 
+                "Keeping track of frequent contributors and their relevant areas of expertise"
+            ]
+        }
+    },
+    {
+        "role": "Core astropy package maintainer (sub-package)",
         "url": "Subpackage_maintainer",
         "role-head": "Sub-package maintainer (at least one per core package sub-package)",
         "sub-roles": [

--- a/roles.json
+++ b/roles.json
@@ -405,7 +405,7 @@
             "description": "Maintain the astropy core package in aspects that are not specific to a single sub-package",
             "details": [
                 "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem, in particular for pull requests spanning multiple sub-packages",
-                "Merging Pull Requests",
+                "Merging Pull Requests that are non-controversial or after reaching out to relevant subpackage maintainers",
                 "Maintain, review, and advocate for useful interaction between multiple sub-packages", 
                 "Keeping track of frequent contributors and their relevant areas of expertise"
             ]


### PR DESCRIPTION
This has been discussed in the dev telecon 2022-02-03 and there was general agreement to add such a role. This PR is a draft of that role description; unfortunately I don't remember exactly how we described this role in the telecon, so this is based on my notes, my recollection and the discussion in https://github.com/astropy/astropy-project/issues/136

@bsipocz You had a very good description of this role in the last dev telecon, but I was not fast enough to write that down. Could you please have a look at this and comment or suggest changes to include what you said?

x-ref: https://github.com/astropy/astropy-project/issues/136

