### PR TITLE
Remove "4 people" from coco role definition

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -9,7 +9,7 @@
             "Adrian Price-Whelan",
             "Erik Tollerud"
         ],
-        "role-head": "Coordination committee member (4 people)",
+        "role-head": "Coordination committee member",
         "responsibilities": {
             "description": "Overall coordination and management of the Astropy project, including:",
             "details": [


### PR DESCRIPTION
The number is wrong, and it is documented in the APE, so this is probably TMI for the team page.