### PR TITLE
Add asdf-astropy as a coordinated package

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -179,7 +179,7 @@
         {
             "name": "asdf-astropy",
             "maintainer": "William Jamieson, Nadia Dencheva, and Perry Greenfield <wjamieson@stsci.edu>",
-            "stable": false,
+            "stable": true,
             "home_url": "https://asdf-astropy.readthedocs.io/en/latest/",
             "repo_url": "https://github.com/astropy/asdf-astropy",
             "pypi_name": "asdf-astropy",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -177,6 +177,26 @@
             }
         },
         {
+            "name": "asdf-astropy",
+            "maintainer": "William Jamieson, Nadia Dencheva, and Perry Greenfield <wjamieson@stsci.edu>",
+            "stable": false,
+            "home_url": "https://asdf-astropy.readthedocs.io/en/latest/",
+            "repo_url": "https://github.com/astropy/asdf-astropy",
+            "pypi_name": "asdf-astropy",
+            "description": "ASDF format support for astropy.",
+            "image": null,
+            "coordinated": true,
+            "review": {
+                "functionality": "General package",
+                "ecointegration": "Good",
+                "documentation": "Good",
+                "testing": "Good",
+                "devstatus": "Good",
+                "python3": "Yes",
+                "last-updated": "2022-05-10"
+            }
+        },
+        {
             "name": "ginga",
             "maintainer": "Eric Jeschke and Pey Lian Lim <eric@naoj.org>",
             "stable": true,

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -193,7 +193,7 @@
                 "testing": "Good",
                 "devstatus": "Good",
                 "python3": "Yes",
-                "last-updated": "2022-05-10"
+                "last-updated": "2022-05-19"
             }
         },
         {


### PR DESCRIPTION
- [x] Wait till 2022-06-02 for a 2-week comment period. See https://groups.google.com/g/astropy-dev/c/XYckfndgrhM

<hr/>

Following the [discussion](https://docs.google.com/document/d/15JSFh3OMF9Iz6ov3q_xxGO_BL8hRnuse4IMUrqEIvcg/edit#bookmark=id.smndathb9rse) at today's Astropy dev telecon, it was decided that `asdf-astropy` should be made a coordinated package given that the functionality provided by `astropy.io.misc.asdf` is being moved from the astropy core to this package.

Tagging @pllim and @dhomeier