### PR TITLE
Add a new role for dev telecons

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -373,6 +373,21 @@
         }
     },
     {
+        "role": "Dev-telecon coordinator",
+        "url": "devtelecon_coordinator",
+        "people": [
+            "Clara Brasseur",
+            "Hans Moritz G\u00fcnther",
+            "Adrian Price-Whelan",
+            "Nathaniel Starkman"
+        ],
+        "role-head": "Developer telecon coordinators",
+        "responsibilities": {
+            "description": "Organize monthly developer telecons",
+            "details": []
+        }
+    },
+    {
         "role": "Release team",
         "url": "release_team",
         "people": [


### PR DESCRIPTION
The Coco discussed developer telecons and decided to add a new role to
the teams page to
(a) give a point of contact for poeple who want to join the telecons, but
for some reasons have individual questions and
(b) ensure that role is not forgotten and appropriate efforts are made
fill it, should the current people in this role stop
doing it for any reason.

Note: By time effort, this is probably one of the smallest roles on the list
but this list is not a credit page - it's just a list
of tasks and people.

CC: @mwcraig