### PR TITLE
Add new voting members elected in July 2022 election

### DIFF
--- a/team.html
+++ b/team.html
@@ -158,6 +158,7 @@
       <li>Stuart Littlefair</li>
       <li>Brett Morris</li>
       <li>Stuart Mumford</li>
+      <li>Ricky O'Steen</li>
       <li>Aarya Patil</li>
       <li>Adrian Price-Whelan</li>
       <li>Thomas Robitaille</li>
@@ -173,6 +174,7 @@
       <li>Erik Tollerud</li>
       <li>James Turner</li>
       <li>Marten van Kerkwijk</li>
+      <li>Eero Vaher</li>
       <li>Zé Vinícius</li>
     </ul>
 


### PR DESCRIPTION
Adding Eero and Ricky, as elected in the July election.