### PR TITLE
Remove APW from two roles

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -378,7 +378,6 @@
         "people": [
             "Clara Brasseur",
             "Hans Moritz G\u00fcnther",
-            "Adrian Price-Whelan",
             "Nathaniel Starkman"
         ],
         "role-head": "Developer telecon coordinators",
@@ -550,7 +549,6 @@
             {
                 "role": "astropy.units",
                 "people": [
-                    "Adrian Price-Whelan",
                     "Nathaniel Starkman",
                     "Marten van Kerkwijk"
                 ]


### PR DESCRIPTION
These are roles that I either will not have time to do in the next year, or haven't been doing effectively.