### PR TITLE
Add Coco policies and communication to teams page

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -27,11 +27,11 @@
                  ]
             },
             {
-                "description": "Organisation and communication:",
+                "description": "Organization and communication:",
                 "details": [
                     "Policies: <a href='https: //github.com/astropy/astropy-project/tree/main/policies/coco-operating-policies.md'>CoCo Operating Policies</a>.",
                     "Meeting records: <a href='https://docs.google.com/document/u/0/d/1kKzSVTom27HiWaw5yTGZDL7vLVAjBGhueXAl2wuSlMY/edit'>CoCo Running Notes</a>.",
-                    "Communication within the coordination committee happens through regular zoom meetings and a private Slack channel.",
+                    "Communication within the coordination committee happens through regular Zoom meetings and a private Slack channel.",
                     "Contact the Coordination Committee via email to <a href='mailto:coordinators@astropy.org'>coordinators@astropy.org</a> or by tagging the <a href='https://github.com/orgs/astropy/teams/coordinators'>github team @astropy/coordinators</a>.",
                     "Coordination committee members send project updates to appropriate email lists (e.g. <a href='https://groups.google.com/u/1/g/astropy-dev'>astropy-dev</a>)."
                 ]

--- a/roles.json
+++ b/roles.json
@@ -29,10 +29,10 @@
             {
                 "description": "Organisation and communication:",
                 "details": [
-                    "The <a href='https: //github.com/astropy/astropy-project/tree/main/policies'>policies are on github</a>, in particular <a href='https: //github.com/astropy/astropy-project/tree/main/policies/coco-operating-policies.md'>in this document</a>.",
-                    "Meeting records are kept <a href='https://docs.google.com/document/u/0/d/1kKzSVTom27HiWaw5yTGZDL7vLVAjBGhueXAl2wuSlMY/edit'>in running notes</a>.",
-                    "Communication with in the coordination committee happes through regular zoom meetings (see running notes) and a private slack channel.",
-                    "Coordination committee members read email to <a href='mailto:coordinators@astropy.org'>coordinators@astropy.org</a> or can be notified as <a href='https://github.com/orgs/astropy/teams/coordinators'>github team @astropy/coordinators</a>.",
+                    "Policies: <a href='https: //github.com/astropy/astropy-project/tree/main/policies/coco-operating-policies.md'>CoCo Operating Policies</a>.",
+                    "Meeting records: <a href='https://docs.google.com/document/u/0/d/1kKzSVTom27HiWaw5yTGZDL7vLVAjBGhueXAl2wuSlMY/edit'>CoCo Running Notes</a>.",
+                    "Communication within the coordination committee happens through regular zoom meetings and a private Slack channel.",
+                    "Contact the Coordination Committee via email to <a href='mailto:coordinators@astropy.org'>coordinators@astropy.org</a> or by tagging the <a href='https://github.com/orgs/astropy/teams/coordinators'>github team @astropy/coordinators</a>.",
                     "Coordination committee members send project updates to appropriate email lists (e.g. <a href='https://groups.google.com/u/1/g/astropy-dev'>astropy-dev</a>)."
                 ]
             }

--- a/roles.json
+++ b/roles.json
@@ -10,21 +10,33 @@
             "Erik Tollerud"
         ],
         "role-head": "Coordination committee member",
-        "responsibilities": {
-            "description": "Overall coordination and management of the Astropy project, including:",
-            "details": [
-		"Formally detailed in the <a href='https://github.com/astropy/astropy-APEs/blob/main/APE0.rst#the-coordination-committee'>The Astropy Project Governance Charter (APE 0)</a>",
-                "Keeping a large-scale view of the Astropy ecosystem",
-                "Evaluating new affiliated package submissions and review of existing affiliated packages",
-                "Approving or rejecting Astropy APEs",
-                "Evaluating and merging core package pull requests as needed (e.g., for sub-packages without a maintainer)",
-                "Arbitrating disagreements in the core package, including final decisions when otherwise deadlocked",
-                "Maintaining the list of roles and related github permissions",
-                "Managing finances for the project",
-                "Coordinating with NumFOCUS and other funding organizations",
-                "Securing funding for the project via discussions and proposals to funding agencies"
-            ]
-        }
+        "responsibilities": [
+            {
+                "description": "Overall coordination and management of the Astropy project, including:",
+                "details": [
+		            "Formally detailed in the <a href='https://github.com/astropy/astropy-APEs/blob/main/APE0.rst#the-coordination-committee'>The Astropy Project Governance Charter (APE 0)</a>",
+                  "Keeping a large-scale view of the Astropy ecosystem",
+                  "Evaluating new affiliated package submissions and review of existing affiliated packages",
+                  "Approving or rejecting Astropy APEs",
+                  "Evaluating and merging core package pull requests as needed (e.g., for sub-packages without a maintainer)",
+                   "Arbitrating disagreements in the core package, including final decisions when otherwise deadlocked",
+                   "Maintaining the list of roles and related github permissions",
+                   "Managing finances for the project",
+                   "Coordinating with NumFOCUS and other funding organizations",
+                   "Securing funding for the project via discussions and proposals to funding agencies"
+                 ]
+            },
+            {
+                "description": "Organisation and communication:",
+                "details": [
+                    "The <a href='https: //github.com/astropy/astropy-project/tree/main/policies'>policies are on github</a>, in particular <a href='https: //github.com/astropy/astropy-project/tree/main/policies/coco-operating-policies.md'>in this document</a>.",
+                    "Meeting records are kept <a href='https://docs.google.com/document/u/0/d/1kKzSVTom27HiWaw5yTGZDL7vLVAjBGhueXAl2wuSlMY/edit'>in running notes</a>.",
+                    "Communication with in the coordination committee happes through regular zoom meetings (see running notes) and a private slack channel.",
+                    "Coordination committee members read email to <a href='mailto:coordinators@astropy.org'>coordinators@astropy.org</a> or can be notified as <a href='https://github.com/orgs/astropy/teams/coordinators'>github team @astropy/coordinators</a>.",
+                    "Coordination committee members send project updates to appropriate email lists (e.g. <a href='https://groups.google.com/u/1/g/astropy-dev'>astropy-dev</a>)."
+                ]
+            }
+        ]
     },
     {
         "role": "Ombudsperson",


### PR DESCRIPTION
Following the policies and reading/writing the communication
is part of the duties of the members of this committe
so it seem appropriate to list that here.
Also, the astropy.org/teams page is the best location where
teams and resposibilites are described. It's
indexed by search engines ans relatively easy to find,
so it seem useful to add this info here instead of
creating a new page just for this.
I'm not worried about making the text
a little longer, since this is rearely read top-to-bottom.