### PR TITLE
Add asdf-astropy to main team page

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -654,6 +654,14 @@
                     "Larry Bradley",
                     "Adam Ginsburg"
                 ]
+            },
+            {
+                "role": "asdf-astropy",
+                "people": [
+                    "Nadia Dencheva",
+                    "Perry Greenfield",
+                    "William Jamieson"
+                ]
             }
         ],
         "responsibilities": {


### PR DESCRIPTION
I noticed that `asdf-astropy` is not listed on the https://www.astropy.org/team.html page under the `Coordinated package maintainer` heading, but it is listed under `Coordinated Packages` on https://www.astropy.org/affiliated/index.html. This PR resolves this difference.