### PR TITLE
add role of the domain name to the web page maintainers

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -269,7 +269,8 @@
             "details": [
                 "Maintaining contributor/roles list",
                 "Managing pull requests to the website repository",
-                "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)"
+                "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)",
+                "Managing the astropy.org DNS entries and releated domain name upkeep"
             ]
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -270,7 +270,7 @@
                 "Maintaining contributor/roles list",
                 "Managing pull requests to the website repository",
                 "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)",
-                "Managing the astropy.org DNS entries and releated domain name upkeep"
+                "Managing the astropy.org DNS entries and related domain name upkeep"
             ]
         }
     },


### PR DESCRIPTION
Prompted by astropy/astropy-project#322 - clarify that domain name work lives in the web page maintainer role