### PR TITLE
Remove Clara from Dev telecon organizer

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -389,7 +389,6 @@
         "role": "Dev-telecon coordinator",
         "url": "devtelecon_coordinator",
         "people": [
-            "Clara Brasseur",
             "Hans Moritz G\u00fcnther",
             "Nathaniel Starkman"
         ],


### PR DESCRIPTION
Clara has indicated by email that she's currently too involved in teaching and getting her PhD done to fill this role. We'd love to have her back, but life happens and the purpose of the roles list is to record who does what right now and whom to contact for anything that comes up related to a specific role. Thus, this PR to remove her from the role, with the understanding that we are happy to add her back in as soon as she has time again.

@ceb8

