### PR TITLE
Roles: GSoC under OpenAstronomy now

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -109,20 +109,6 @@
         }
     },
     {
-        "role": "Astropy GSoC coordinator",
-        "url": "Astropy_GSoC_coordinator",
-        "people": [
-            "Brigitta Sip\u0151cz",
-            "Erik Tollerud",
-            "Z\u00e9 Vin\u00edcius"
-        ],
-        "role-head": "Astropy GSoC coordinator",
-        "responsibilities": {
-            "description": "Coordinate the participation of Astropy in the Google Summer of Code Project",
-            "details": []
-        }
-    },
-    {
         "role": "Learn Team",
         "url": "Learn_team",
 	"role-head": "Learn Team",


### PR DESCRIPTION
Astropy has not been active for several years now. And even if it becomes active again, it would be under OpenAstronomy. For instance, see https://openastronomy.org/gsoc/gsoc2023/#/mentors for GSoC 2023.

Or do you think we should keep the role but link directly to OpenAstronomy page? I don't see a "roles" page that that is not by year. Maybe I missed it?

Affected people in the removed listings:

* @bsipocz 
* @eteq 
* @mirca