### PR TITLE
Roles: Merge documentation infrastructure and testing infrastructure

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -239,6 +239,7 @@
                 "Overseeing content (although primary responsibility for content lies with subpackage maintainers)",
                 "Managing issues/pull request for the Astropy core package regarding testing infrastructure",
                 "Managing issues/pull requests in the repositories containing the testing plugins, and determining when new plugins are required",
+                "Set up and maintain continuous integration services",
                 "Maintaining the 'metapackage' with the testing machinery (pytest-astropy at the time of this writing)",
                 "Supporting and enabling affiliated package usage of the testing infrastructure"
             ]

--- a/roles.json
+++ b/roles.json
@@ -232,7 +232,7 @@
         ],
         "role-head": "Core infrastructure maintainer",
         "responsibilities": {
-            "description": "Lead development and maintenance of the documentation and testing infrastructure for Astropy and the helpers, including:",
+            "description": "Lead development and maintenance of the documentation and testing infrastructure (also see <a href='https://github.com/astropy/astropy-project/tree/main/infrastructure'>infrastructure</a>) for Astropy and the helpers, including:",
             "details": [
                 "Managing the Sphinx infrastructure",
                 "Implementing changes and improvements to the documentation website",

--- a/roles.json
+++ b/roles.json
@@ -222,21 +222,25 @@
         }
     },
     {
-        "role": "Documentation infrastructure maintainer",
-        "url": "Documentation_infrastructure_maintainer",
+        "role": "Core infrastructure maintainer",
+        "url": "Core_infrastructure_maintainer",
         "people": [
             "Simon Conseil",
             "Pey Lian Lim",
             "Thomas Robitaille",
             "Brigitta Sip\u0151cz"
         ],
-        "role-head": "Documentation infrastructure maintainer",
+        "role-head": "Core infrastructure maintainer",
         "responsibilities": {
-            "description": "Maintain the <a href='http://docs.astropy.org/en/stable/index.html'>Astropy documentation</a> website, including:",
+            "description": "Lead development and maintenance of the documentation and testing infrastructure for Astropy and the helpers, including:",
             "details": [
                 "Managing the Sphinx infrastructure",
                 "Implementing changes and improvements to the documentation website",
-                "Overseeing content (although primary responsibility for content lies with subpackage maintainers)"
+                "Overseeing content (although primary responsibility for content lies with subpackage maintainers)",
+                "Managing issues/pull request for the Astropy core package regarding testing infrastructure",
+                "Managing issues/pull requests in the repositories containing the testing plugins, and determining when new plugins are required",
+                "Maintaining the 'metapackage' with the testing machinery (pytest-astropy at the time of this writing)",
+                "Supporting and enabling affiliated package usage of the testing infrastructure"
             ]
         }
     },
@@ -309,26 +313,6 @@
                 "Ensure adequate labeling of issues and pull requests",
                 "Perform initial triaging of issues and pull requests, including moving between repositories",
                 "Merge non-controversial pull requests"
-            ]
-        }
-    },
-    {
-        "role": "Testing infrastructure maintainer",
-        "url": "Testing_infrastructure_maintainer",
-        "people": [
-            "Simon Conseil",
-            "Pey Lian Lim",
-            "Thomas Robitaille",
-            "Brigitta Sip\u0151cz"
-        ],
-        "role-head": "Testing infrastructure maintainer",
-        "responsibilities": {
-            "description": "Lead development and maintenance of the testing infrastructure for Astropy and the helpers, including:",
-            "details": [
-                "Managing issues/pull request for the Astropy core package regarding testing infrastructure",
-                "Managing issues/pull requests in the repositories containing the testing plugins, and determining when new plugins are required",
-                "Maintaining the 'metapackage' with the testing machinery (pytest-astropy at the time of this writing)",
-                "Supporting and enabling affiliated package usage of the testing infrastructure"
             ]
         }
     },


### PR DESCRIPTION
Documentation and testing infrastructure are closely related and both are actually managed by the same set of people in reality. say, it is tough to maintain `pytest-astropy` without also touching `sphinx-astropy` since doctest tie them together. And both documentation and tests are done in the same manner (e.g., the CI checks for PR).

If simply merging them is too controversial, we can also try to have each of them as "sub-role" but shared by the same set of people. 🤷 

Affected people in the merged listings:

* @saimn 
* @pllim 
* @astrofrog 
* @bsipocz 

TODO:

- [x] Link to chart from https://github.com/astropy/astropy-project/issues/118 once it is updated and in the repo.
- [ ] Add sub-roles for the many things that we actually work on