### PR TITLE
Roles: Add specreduce to Coordinated section

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -662,6 +662,13 @@
                     "Perry Greenfield",
                     "William Jamieson"
                 ]
+            },
+            {
+                "role": "specreduce",
+                "people": [
+                    "Tim Pickering",
+                    "Erik Tollerud"
+                ]
             }
         ],
         "responsibilities": {


### PR DESCRIPTION
`specreduce` is listed as Coordinated under https://www.astropy.org/affiliated/index.html#coordinated-package-list but not listed in `roles.json`. Here, I simply copy over the "Maintainer(s)" listed over there to this JSON file. Whether they are really actively maintaining or not, I do not know. If this listing is no longer accurate, please tell me the current maintainers for `specreduce`. Thanks!

Affected people in the added listing:

* @tepickering
* @eteq 