### PR TITLE
Roles: SOSS now core maintainer

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -275,25 +275,6 @@
         }
     },
     {
-        "role": "DevOps and Operations Specialist",
-        "url": "devops_team",
-        "people": [
-            "E. Madison Bray",
-            "Pey Lian Lim",
-            "Brigitta Sip\u0151cz"
-        ],
-        "role-head": "DevOps and Operations",
-        "responsibilities": {
-            "description": "Ensure the smooth running of the project",
-            "details": [
-                "Set up and maintain continuous integration services",
-                "Ensure adequate labeling of issues and pull requests",
-                "Perform initial triaging of issues and pull requests, including moving between repositories",
-                "Merge non-controversial pull requests"
-            ]
-        }
-    },
-    {
         "role": "Testing infrastructure maintainer",
         "url": "Testing_infrastructure_maintainer",
         "people": [
@@ -398,8 +379,10 @@
                 "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem, in particular for pull requests spanning multiple sub-packages",
                 "Merging Pull Requests that are non-controversial or after reaching out to relevant subpackage maintainers",
                 "Maintain, review, and advocate for useful interaction between multiple sub-packages", 
-                "Perform initial triaging of issues and pull requests",
-                "Keeping track of frequent contributors and their relevant areas of expertise"
+                "Perform initial triaging of issues and pull requests, including moving between repositories",
+                "Ensure adequate labeling of issues and pull requests",
+                "Keeping track of frequent contributors and their relevant areas of expertise",
+                "Set up and maintain continuous integration services"
             ]
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -381,8 +381,7 @@
                 "Maintain, review, and advocate for useful interaction between multiple sub-packages", 
                 "Perform initial triaging of issues and pull requests, including moving between repositories",
                 "Ensure adequate labeling of issues and pull requests",
-                "Keeping track of frequent contributors and their relevant areas of expertise",
-                "Set up and maintain continuous integration services"
+                "Keeping track of frequent contributors and their relevant areas of expertise"
             ]
         }
     },


### PR DESCRIPTION
SOSS hiring had lapsed. The tasks have, in practice, been absorbed by those in the "core maintainer" role.

Affected people in the listings:

* @embray 
* @pllim 
* @bsipocz 
* @dhomeier 

TODO:

- [x] Move "Set up and maintain continuous integration services" to #520 