### PR TITLE
Roles: Remove sub-role for community engagement coordinator

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -59,44 +59,12 @@
         "role": "Community engagement coordinator",
         "url": "Community_engagement_coordinator",
         "role-head": "Community engagement coordinator",
-        "sub-roles": [
-            {
-                "role": "Overall",
-                "people": [
-                    "Unfilled"
-                ]
-            },
-            {
-                "role": "Twitter",
-                "people": [
-                    "Matt Craig"
-                ]
-            },
-            {
-                "role": "Facebook",
-                "people": [
-                    "Kelle Cruz",
-                    "Erik Tollerud"
-                ]
-            },
-            {
-                "role": "Slack/Matrix",
-                "people": [
-                    "Stuart Mumford"
-                ]
-            },
-            {
-                "role": "Discourse",
-                "people": [
-                    "Stuart Mumford"
-                ]
-            },            {
-                "role": "Conferences",
-                "people": [
-                    "Kelle Cruz",
-                    "Erik Tollerud"
-                ]
-            }
+        "people": [
+            "Matt Craig (Twitter)",
+            "Kelle Cruz (Facebook, Conferences)",
+            "Stuart Mumford (Discourse/Matrix/Slack)",
+            "Erik Tollerud (Facebook, Conferences",
+
         ],
         "responsibilities": {
             "description": "Facilitate engagement with the astropy community, including:",
@@ -104,7 +72,7 @@
                 "Maintain the @astropy twitter account",
                 "Monitor/moderate the Python Users in Astronomy Facebook group",
                 "Keep track of/help organize conferences and workshops",
-	  	"Maintain infrastructure for a specific channel (e.g., discourse)"
+	  	        "Maintain infrastructure for a specific channel (e.g., Discourse)"
             ]
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -63,8 +63,7 @@
             "Matt Craig (Twitter)",
             "Kelle Cruz (Facebook, Conferences)",
             "Stuart Mumford (Discourse/Matrix/Slack)",
-            "Erik Tollerud (Facebook, Conferences",
-
+            "Erik Tollerud (Facebook, Conferences)"
         ],
         "responsibilities": {
             "description": "Facilitate engagement with the astropy community, including:",

--- a/roles.json
+++ b/roles.json
@@ -71,7 +71,7 @@
                 "Maintain the @astropy twitter account",
                 "Monitor/moderate the Python Users in Astronomy Facebook group",
                 "Keep track of/help organize conferences and workshops",
-	  	        "Maintain infrastructure for a specific channel (e.g., Discourse)"
+	  	        "Maintain the infrastructure of the relevant discussion forums and platforms."
             ]
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -60,13 +60,13 @@
         "url": "Community_engagement_coordinator",
         "role-head": "Community engagement coordinator",
         "people": [
-            "Matt Craig (Twitter)",
-            "Kelle Cruz (Facebook, Conferences)",
-            "Stuart Mumford (Discourse/Matrix/Slack)",
-            "Erik Tollerud (Facebook, Conferences)"
+            "Matt Craig",
+            "Kelle Cruz",
+            "Stuart Mumford",
+            "Erik Tollerud"
         ],
         "responsibilities": {
-            "description": "Facilitate engagement with the astropy community, including:",
+            "description": "Facilitate engagement with the astropy community, as laid out in <a href='https://github.com/astropy/astropy-project/tree/main/community_engagement'>community_engagement</a>, including:",
             "details": [
                 "Maintain the @astropy twitter account",
                 "Monitor/moderate the Python Users in Astronomy Facebook group",


### PR DESCRIPTION
I think it is overkill to have so many sub-roles for community engagement. Infrastructure staff maintains multiple packages across the board (and manages releases for them too, etc) and yet we do not list all those packages on this page.

Affected people in this listing:

* @mwcraig 
* @kelle 
* @eteq 
* @Cadair 

TODO:

- [x] `community-engagement/README.md` to capture info removed from Roles page
- [x] Move `TwitterGuidelines.md` to `community-engagement/` also
- [x] Link to `community-engagement/` from roles

Depends on:

* https://github.com/astropy/astropy-project/pull/331