### PR TITLE
Roles: Remove sub-role for Learn Team

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -127,53 +127,24 @@
         "url": "Learn_team",
         "role-head": "Learn Team",
         "people": [
-            "Lia Corrales (coordinator, content editor)",
-            "Matt Craig (coordinator, content editor)",
-            "Kelle Cruz (coordinator, content editor, workshop coordinator)",
-            "Brett Morris (workshop coordinator)",
-            "Adrian Price-Whelan (coordinator, infrastructure, content editor)",
-            "David Shupe (workshop coordinator)",
-            "Jonathan Sick (infrastructure)",
-            "Erik Tollerud (infrastructure)"
+            "Lia Corrales",
+            "Matt Craig",
+            "Kelle Cruz",
+            "Brett Morris",
+            "Adrian Price-Whelan",
+            "David Shupe",
+            "Jonathan Sick",
+            "Erik Tollerud"
         ],
-        "responsibilities": [
-            {
-		"subrole-head": "Coordinators",
-		"description": "Oversee the Astropy \"Learn\" ecosystem, including:",
-		"details": [
-                    "Ensuring that the documentation, tutorials, and guide materials are internally consistent and cover key areas of the ecosystem",
-                    "Overseeing the maintainers for the aforementioned areas",
-                    "Organizing sprints or other events focused on Astropy learning materials"
-		]
-	    },
-	    {
-                "subrole-head": "Infrastructure Maintainers",
-                "description": "Maintain the <a href='http://www.astropy.org/astropy-tutorials/'>Tutorials website</a>, including:",
-                "details": [
-                    "Facilitating the display and discoverability of the tutorials",
-                    "Rendering of the Jupyter notebooks",
-                    "Integrated testing of notebooks"
-                ]
-	    },
-	    {
-                "subrole-head": "Content Editors",
-                "description": "Oversee the material included in Tutorials and Guides, including:",
-                "details": [
-                    "Reviewing issues and pull requests",
-                    "Soliciting new content as needed",
-                    "Working with Infrastructure Maintainers to maintain website"
-                ]
-            },
-	    {
-		"subrole-head": "Workshop Coordinators",
-		"description": "Organize and coordinate Astropy workshops for training and outreach to users",
-		"details": [
-                    "Maintain the astropy-workshops repository",
-                    "Oversee staffing/volunteers for workshops",
-                    "Identify opportunities for workshops in diverse geographic locations"
-		]
+        "responsibilities": {
+            "description": "Maintain the Learn ecosystem, as laid out in <a href='https://github.com/astropy/astropy-project/tree/main/learn'>learn</a>, including:",
+            "details": [
+                "Oversee the Astropy Learn ecosystem.",
+                "Maintain the Tutorials website.",
+                "Oversee the material included in Tutorials and Guides.",
+                "Organize and coordinate Astropy workshops for training and outreach to users."
+            ]
 	    }
-	]
     },
     {
         "role": "Finance committee member",

--- a/roles.json
+++ b/roles.json
@@ -125,43 +125,17 @@
     {
         "role": "Learn Team",
         "url": "Learn_team",
-	"role-head": "Learn Team",
-	"sub-roles": [
-	    {
-		"role": "Coordinators",
-		"people": [
-		    "Lia Corrales",
-		    "Kelle Cruz",
-		    "Adrian Price-Whelan",
-		    "Matt Craig"
-		]
-	    },
-	    {
-		"role": "Infrastructure",
-		"people": [
-		    "Adrian Price-Whelan",
-		    "Erik Tollerud",
-		    "Jonathan Sick"
-		]
-	    },
-	    {
-		"role": "Content Editors",
-		"people": [
-		    "Lia Corrales",
-		    "Kelle Cruz",
-		    "Matt Craig",
-		    "Adrian Price-Whelan"
-		]
-	    },
-	    {
-		"role": "Workshop Coordinators",
-		"people": [
-		    "David Shupe",
-		    "Brett Morris",
-		    "Kelle Cruz"
-		]
-	    }
-	],
+        "role-head": "Learn Team",
+        "people": [
+            "Lia Corrales (coordinator, content editor)",
+            "Matt Craig (coordinator, content editor)",
+            "Kelle Cruz (coordinator, content editor, workshop coordinator)",
+            "Brett Morris (workshop coordinator)",
+            "Adrian Price-Whelan (coordinator, infrastructure, content editor)",
+            "David Shupe (workshop coordinator)",
+            "Jonathan Sick (infrastructure)",
+            "Erik Tollerud (infrastructure)"
+        ],
         "responsibilities": [
             {
 		"subrole-head": "Coordinators",


### PR DESCRIPTION
I think it is a little overkill to have so many sub-roles for Learn Team. Infrastructure staff maintains multiple packages across the board (and manages releases for them too, etc) and yet we do not list all those packages on this page.

This PR eliminates sub-role for Learn Team but kept them in parenthesis since I also notice you have sub-responsibility. This is not ideal but it is getting late and I cannot think of anything better. Ideas welcome. If we can make this more fluid, then when you move Learn staff around the team, you don't have to constantly come back to update this page.

Affected people in this listing:

* @eblur 
* @kelle 
* @adrn 
* @mwcraig 
* @eteq 
* @jonathansick
* @stargaser
* @bmorris3 

TODO (from https://github.com/astropy/astropy.github.com/pull/524#issuecomment-1457189892):

- [x] `learn/README.md` to capture info removed from Roles page and move "the description at the bottom of the page" over
- [x] Link to `learn/` from roles

Depends on:

* https://github.com/astropy/astropy-project/pull/332

Also see:

* https://github.com/astropy/astropy-tutorials/issues/580
* https://github.com/astropy/learn-astropy/issues/71