### PR TITLE
Proposed affiliated package: martini

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1,6 +1,25 @@
 {
     "packages": [
         {
+          "name": "martini",
+          "maintainer": "Kyle Oman <kyle.a.oman@durham.ac.uk>",
+          "stable": true,
+          "home_url": "https://martini.readthedocs.io/en/latest/",
+          "repo_url": "https://github.com/kyleaoman/martini",
+          "pypi_name": "astromartini",
+          "description": "For creating synthetic spatially-resolved HI line observations (data cubes) of smoothed-particle hydrodynamics simulations of galaxies.",
+          "coordinated": false,
+          "review": {
+            "functionality": "To be filled out by the reviewer",
+            "ecointegration": "To be filled out by the reviewer",
+            "documentation": "To be filled out by the reviewer",
+            "testing": "To be filled out by the reviewer",
+            "devstatus": "To be filled out by the reviewer",
+            "python3": "To be filled out by the reviewer",
+            "last-updated": "To be filled out by the reviewer"
+          }
+        },
+        {
           "name": "BayesicFitting",
           "maintainer": "Do Kester and Migo Mueller <dokester@home.nl>",
           "stable": true,


### PR DESCRIPTION
[Martini](https://github.com/kyleaoman/martini/) is a modular package for the creation of synthetic resolved HI line observations (data cubes) of smoothed-particle hydrodynamics simulations of galaxies. I make extensive use of astropy.units, astropy.coordinates and astropy.fits, plus some other bits and bobs. I've just completed a comprehensive overhaul to a v2.0 with CI, docs, etc. so it seems like a good time to request a review and perhaps for martini to become an affiliated package.