### PR TITLE
Roles: Update release team members

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -366,10 +366,8 @@
         "role": "Release team",
         "url": "release_team",
         "people": [
-            "E. Madison Bray",
             "Simon Conseil",
-            "Thomas Robitaille",
-            "Brigitta Sip\u0151cz"
+            "Thomas Robitaille"
         ],
         "role-head": "Release team",
         "responsibilities": {


### PR DESCRIPTION
In the past several releases (and we only do a release every 6 months, so it's been a while), only @astrofrog and @saimn are alternating, so based on that, I am updating the Release Team membership.

Affected people in this listing:

* @embray 
* @bsipocz 

And, I have to confess that I accidentally already updated the actual "Astropy Project Release Team" GitHub membership. I thought this was already done over here but I must have imagined it. So, if this PR ends up changing, I'll update on GitHub side accordingly. I take full responsibility for this mistake and I apologize for any inconvenience caused.