### PR TITLE
Reword the purpose of the roles pages

### DIFF
--- a/team.html
+++ b/team.html
@@ -82,10 +82,11 @@
 		encompasses a broad scope of responsibilities ranging from
 		direct package development to communication, distribution, and
 		managerial activities.  In this section we list the identified
-		project roles and responsible parties, both to formally
-		acknowledge those performing these duties and to solicit
-		volunteers for these roles to ensure sustainability.  See
-		the <a href="#role-responsibilities">Astropy project role
+		project roles and responsible parties, to provide members with a
+		point-of-contact for individual tasks and to give the project an
+		overview of the current state of the team. Roles on this page are
+		very different in scope and effort needed to perform them.
+        See	the <a href="#role-responsibilities">Astropy project role
 		responsibilities</a> section below for a full description of each
 		role.
 

--- a/team.html
+++ b/team.html
@@ -84,9 +84,11 @@
 		managerial activities.  In this section we list the identified
 		project roles and responsible parties, to provide members with a
 		point-of-contact for individual tasks and to give the project an
-		overview of the current state of the team. Roles on this page are
-		very different in scope and effort needed to perform them.
-        See	the <a href="#role-responsibilities">Astropy project role
+		overview of the current state of the team. Different roles on this
+		page have very different scope and effort needed to perform them.
+		Listing on this page is also not mean to be any particular assignment
+		of credit beyond that implict in having the responsibilities of the role.
+                See	the <a href="#role-responsibilities">Astropy project role
 		responsibilities</a> section below for a full description of each
 		role.
 


### PR DESCRIPTION
In the Astropy Coordination meeting 2023 we discussed that in practice we use the roles page often like a phone book. Who is responsible for what? Which duties are not covered? If someone leaves / retires which roles need to be filled again?

Thus, I'm attempting to reword it in that direction. I'm explicitly taking off the word "acknowledge" as I don't think that needs explicit mention - people do and will use the roles pages like that in the future anyway and it's implicit in the list. In the past, many of the critizisms we had about the purpose and the filling of the roles pages stem from people putting too much effort on the acknowledge aspect and then they object to being removed form a role because they ae "emotionally attached" or because "XYZ is also listed and they put in less work". That later sentiment inspired the new sentence to explicitly say that roles have a different scope and it's unfair to just count up how often a name is on the list. Some people with half a dozen roles perform less work then people not even listed here; but if those half a dozen jobs fullfil different functions they might be listed separately, even if each of them is a very small amount of work. In that sense, this page is not well suited to assess contribution or credit.

That said, of course a mention on this page is also a form of giving credit, with all the caveats I listed above.

CC: @pllim @kelle @eteq @weaverba137 @saimn @aaryapatil 

I suggest that we collect a number of PRs and send out an email to astropy-dev will a pointer to all of them at the end of this meeting asking for comments and this one should go on that list.