### PR TITLE
Roles: Move Finance Committee to after Ombudsperson

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -56,6 +56,26 @@
         }
     },
     {
+        "role": "Finance committee member",
+        "url": "finance_committee_member",
+        "people": [
+            "Kelle Cruz",
+            "Aarya Patil",
+            "John Swinbank",
+            "Erik Tollerud"
+        ],
+        "role-head": "Finance committee member",
+        "responsibilities": {
+            "description": "Plan, oversee, and disburse the Astropy project finances, including:",
+            "details": [
+                "Determine and manage the process for paying people from Astropy's project-level funding.",
+                "Paying and overseeing people in supporting roles (e.g., documentation copy-editors, contract lawyers).",
+                "Oversee payment for services, licenses, and travel (e.g., Python in Astro, SciPy), and other miscellaneous expenses the project already pays for.",
+                "Maintain and continuously develop a transparent process for reporting all of the above to the Coordination Committee and wider community, related record keeping, and planning the same for future possible financial committee efforts."
+            ]
+        }
+    },
+    {
         "role": "Community engagement coordinator",
         "url": "Community_engagement_coordinator",
         "role-head": "Community engagement coordinator",
@@ -186,26 +206,6 @@
 		]
 	    }
 	]
-    },
-    {
-        "role": "Finance committee member",
-        "url": "finance_committee_member",
-        "people": [
-            "Kelle Cruz",
-            "Aarya Patil",
-            "John Swinbank",
-            "Erik Tollerud"
-        ],
-        "role-head": "Finance committee member",
-        "responsibilities": {
-            "description": "Plan, oversee, and disburse the Astropy project finances, including:",
-            "details": [
-                "Determine and manage the process for paying people from Astropy's project-level funding.",
-                "Paying and overseeing people in supporting roles (e.g. documentation copy-editors, contract lawyers).",
-                "Oversee payment for services, licenses, and travel (e.g., Python in Astro, SciPy), and other miscellaneous expenses the project already pays for.",
-                "Maintain and continuously develop a transparent process for reporting all of the above to the Coordination Committee and wider community, related record keeping, and planning the same for future possible financial committee efforts."
-            ]
-        }
     },
     {
         "role": "Documentation infrastructure maintainer",


### PR DESCRIPTION
As discussed and agreed upon at Astropy Coordination Meeting 2023 (myself, @eteq, @hamogu, @weaverba137, @aaryapatil, @saimn), Finance Committee shall be moved up to after Ombudsperson. This is because given that the committee now oversees multiple grants for the Project and so on, that would be a logical (and hopefully uncontroversial) place to put it.

Affected people (the Finance Committee):

* @kelle 
* @aaryapatil
* @jdswinbank 
* @eteq 

Out of scope: Re-ordering of all other roles.

This is part of #519 