### PR TITLE
Roles: Remove Madison due to inactivity

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -264,7 +264,6 @@
         "role": "DevOps and Operations Specialist",
         "url": "devops_team",
         "people": [
-            "E. Madison Bray",
             "Pey Lian Lim",
             "Brigitta Sip\u0151cz"
         ],
@@ -352,7 +351,6 @@
         "role": "Release team",
         "url": "release_team",
         "people": [
-            "E. Madison Bray",
             "Simon Conseil",
             "Thomas Robitaille",
             "Brigitta Sip\u0151cz"


### PR DESCRIPTION
The SOSS contract has ended. Furthermore, Madison has not been active in the assigned roles for a while. Therefore at Astropy Coordination Meeting 2023 (myself, @eteq, @hamogu, @weaverba137, @aaryapatil, @saimn), we decided to remove them from those roles.

Affected person:

* @embray 

Keep in mind that Madison still had made very valuable contributions and those are reflected in https://www.astropy.org/credits.html . They are also still a Voting Member.

Part of #519 , half the changes here is also subset of #530