### PR TITLE
Removing myself from Facebook community role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -75,8 +75,7 @@
             {
                 "role": "Facebook",
                 "people": [
-                    "Kelle Cruz",
-                    "Erik Tollerud"
+                    "Kelle Cruz"
                 ]
             },
             {


### PR DESCRIPTION
This PR is me removing myself from this role - in practice I do not use Facebook anymore so I cannot be effective in this role (although I still occasionally can pop in to leave comments when pinged).

cc @pllim who reminded me I can do this myself after I said it in the roles survey :wink: 