### PR TITLE
Add Ole Streicher as general maintainer for the Astropy core package

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -374,7 +374,8 @@
         "url": "Core_package_general_maintainer",
         "people": [
             "Derek Homeier",
-            "Pey Lian Lim"
+            "Pey Lian Lim",
+            "Ole Streicher"
         ],
         "role-head": "Core astropy package maintainer (general)",
         "responsibilities": {


### PR DESCRIPTION
Adding @olebole in this role with write access in astropy/astropy, in response to https://github.com/astropy/astropy-project/issues/327#issuecomment-1557532580 .