### PR TITLE
Reorganize Learn team

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -115,27 +115,18 @@
 	    {
 		"role": "Coordinators",
 		"people": [
-		    "Lia Corrales",
-		    "Kelle Cruz",
-		    "Adrian Price-Whelan",
-		    "Matt Craig"
+		    "Unfilled"
 		]
 	    },
 	    {
-		"role": "Infrastructure",
+		"role": "Learn content and infrastructure",
 		"people": [
+            "Lia Corrales",
+            "Kelle Cruz",
+            "Matt Craig",
 		    "Adrian Price-Whelan",
 		    "Erik Tollerud",
 		    "Jonathan Sick"
-		]
-	    },
-	    {
-		"role": "Content Editors",
-		"people": [
-		    "Lia Corrales",
-		    "Kelle Cruz",
-		    "Matt Craig",
-		    "Adrian Price-Whelan"
 		]
 	    },
 	    {
@@ -158,21 +149,14 @@
 		]
 	    },
 	    {
-                "subrole-head": "Infrastructure Maintainers",
-                "description": "Maintain the <a href='http://www.astropy.org/astropy-tutorials/'>Tutorials website</a>, including:",
+                "subrole-head": "Learn content and infrastructure",
+                "description": "Maintain the infrastructure and edit content of the <a href='http://www.astropy.org/astropy-tutorials/'>Tutorials website</a>, including:",
                 "details": [
                     "Facilitating the display and discoverability of the tutorials",
                     "Rendering of the Jupyter notebooks",
-                    "Integrated testing of notebooks"
-                ]
-	    },
-	    {
-                "subrole-head": "Content Editors",
-                "description": "Oversee the material included in Tutorials and Guides, including:",
-                "details": [
+                    "Integrated testing of notebooks",
                     "Reviewing issues and pull requests",
-                    "Soliciting new content as needed",
-                    "Working with Infrastructure Maintainers to maintain website"
+                    "Soliciting new content as needed"
                 ]
             },
 	    {


### PR DESCRIPTION
The previous leadership team does not have the time to lead learn any more, but they are going to be involved as contributors going forward. We discussed this today at a telecon and decided to mark the leadership role as "unfilled". Additionally, with the current level of effort and structure, the split between leanr infracstruture and editors is somewhat artificial, e.g. people listed on the infrastructure side might "merge and review PRs" if it's only about fixing things, although that was previously described as the responsibility of the editors only.

If the roles grow again, we can split this out again at a later time.

@kelle @eteq @adrn @mwcraig @eblur 

CC: @pllim 