### PR TITLE
Add Derek and Moritz to website maintainers for sites.json

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -229,15 +229,16 @@
         "role": "Astropy.org web page maintainer",
         "url": "Astropyorg_web_page_maintainer",
         "people": [
-            "Adrian Price-Whelan",
+            "Hans Moritz G\u00fcnther",
+            "Derek Homeier",
             "Erik Tollerud"
         ],
         "role-head": "Astropy.org web page maintainer",
         "responsibilities": {
             "description": "Manage the <a href='http://astropy.org'>astropy.org</a> web site, including:",
             "details": [
-                "Maintaining contributor/roles list",
-                "Managing pull requests to the website repository",
+                "Managing pull requests to the website repository in general",
+                "and for the sites.json file in particular",
                 "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)",
                 "Managing the astropy.org DNS entries and related domain name upkeep"
             ]

--- a/roles.json
+++ b/roles.json
@@ -238,7 +238,6 @@
             "description": "Manage the <a href='http://astropy.org'>astropy.org</a> web site, including:",
             "details": [
                 "Managing pull requests to the website repository in general",
-                "and for the sites.json file in particular",
                 "Managing <a href='http://data.astropy.org'>data.astropy.org</a>, which is done by managing the astropy-data repository (which is automatically synced with <a href='http://data.astropy.org'>data.astropy.org</a>)",
                 "Managing the astropy.org DNS entries and related domain name upkeep"
             ]


### PR DESCRIPTION
Updates to sites.json compromise the vast majority of all PRs to the website repro in the last few years and Derek and Moritz took care of most of those. So, in an effort to keep the list of people current with what everyone does, this PR adds Derek and Moritz as maintainers for the repro filling the role left by Adrian.

It also removes the "keep list of roles" role, since that's listed for the Coco already.