### PR TITLE
Add Europlanet credits

### DIFF
--- a/credits.html
+++ b/credits.html
@@ -288,7 +288,13 @@ group.
 <h3>Dunlap</h3>
 Dunlap has provided Financial support/seed funding for the Astropy Learn project since 2020.
 
-		<p>
+<h3>Europlanet Society</h3>
+The Europlanet society has awarded funding for the Astropy Project through the Europlanet 2024 RI,
+European Union's Horizon 2020 research and innovation programme, under grant agreement No 871149.
+This funding is used in particular to support the ongoing work on planetary reference frames and
+world coordinate system.
+
+	<p>
 		<img style="vertical-align:middle" src="images/astropy_brandmark.png" height=20><span style="vertical-align:middle">
         <a href="code_of_conduct.html"> The Astropy project is committed to fostering an inclusive community</a></span>.
         </p>


### PR DESCRIPTION
Dear maintainers,

as discussed offline with @hamogu and @erard, this pull request add a paragraph to the [Credits](https://www.astropy.org/credits.html) page, about the Europlanet funding for planetary coordinate support.

Thank you for considering it.