### PR TITLE
specreduce: Add Kyle and Clare as maintainers because they already are

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -582,7 +582,9 @@
                 "role": "specreduce",
                 "people": [
                     "Tim Pickering",
-                    "Erik Tollerud"
+                    "Erik Tollerud",
+                    "Kyle Conroy",
+                    "Clare Shanahan"
                 ]
             }
         ],


### PR DESCRIPTION
@kecnry and @cshanahan1 already have maintainer access to `specreduce` for a while as individuals and they are actively maintaining the package. I have taken the liberty to clean up `specreduce` and `specreduce-data` permissions by doing the following and this PR just making their existing jobs official.

* Remove individuals with only Read access to `specreduce`. This is unnecessary because it is a public repo. If you want them to have access for triage, create a proper triage team. Refrain from providing arbitrary individual access.
* Added Kyle and Clare to https://github.com/orgs/astropy/teams/specreduce-maintainers and downgrade that team's access from Admin to Maintain.
* Created a new admin team with existing admins (@eteq and @tepickering) and give them back their existing access but under a new team name.

All in all, there are no changes to existing access. I am just making things official. I think it is nice to give people who are doing the work some credit officially.