### PR TITLE
specutils: Add Brigitta as maintainer because she already is in the team

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -553,7 +553,8 @@
                     "Nicholas Earl",
                     "Adam Ginsburg",
                     "Ricky O'Steen",
-                    "Erik Tollerud"
+                    "Erik Tollerud",
+                    "Brigitta Sip\u0151cz"
                 ]
             },
             {


### PR DESCRIPTION
I took the liberty to clean up `specutils` access by doing the following:

* Removing individuals with Read/Triage/Write access (after consulting with Ricky) because they are either unnecessary, no longer active, or added without a good cause.
* Removing `astropy-contributors` Team with Read access. Not sure what this is for. I didn't see it listed in `specreduce`.
* Removing `astropy-project-release-team`. This team is for `astropy` release and it is not on the hook for Coordinated packages that are supposed to have their own maintainers.
* Downgrading `devops-maintainers` from Admin to Maintain. I think the infrastructure is okay now, so DevOps does not need to be so involved now but I have no doubt the Admin access was needed at some point.
* Retaining the existing Admin access for `specutils-maintainers` but sync it with the Team page (hence this PR). I recognize that every package gets maintained differently but if you find yourselves needing sub-team with Admin and not everyone here, I would be happy to help you set it up.

cc @keflavich @eteq @nmearl @bsipocz @rosteen 