### PR TITLE
Proposed affiliated package: PetroFit (pyOpenSci/software-submission#159)

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1,6 +1,25 @@
 {
     "packages": [
         {
+          "name": "PetroFit",
+          "maintainer": "Robel Geda and Steve Crawford <robel@princeton.edu>",
+          "stable": true,
+          "home_url": "https://petrofit.readthedocs.io/en/latest/index.html",
+          "repo_url": "https://github.com/PetroFit/petrofit",
+          "pypi_name": "petrofit",
+          "description": "Package for calculating Petrosian properties (radii, concentration, etc.) and fitting 2D galaxy light profiles (Sersic, Nuker, Core Sersic etc.)",
+          "coordinated": false,
+          "review": {
+             "functionality": "To be filled out by the reviewer",
+             "ecointegration": "To be filled out by the reviewer",
+             "documentation": "To be filled out by the reviewer",
+             "testing": "To be filled out by the reviewer",
+             "devstatus": "To be filled out by the reviewer",
+             "python3": "To be filled out by the reviewer",
+             "last-updated": "To be filled out by the reviewer"
+          }
+        },
+        {
           "name": "regularizePSF",
           "maintainer": "Marcus Hughes <marcus.hughes@swri.org>",
           "stable": true,


### PR DESCRIPTION
EDIT: Superseded by https://github.com/pyOpenSci/software-submission/issues/159

PetroFit is a Python package designed for calculating Petrosian properties, such as radii and concentration indices, as well as fitting galaxy light profiles. In particular, PetroFit includes tools for performing accurate photometry, segmentations, Petrosian profiling, and Sérsic fitting. PetroFit is based on PhotUtils and AstroPy; and we hope to contribute the more generalized aspects of our code upstream for other packages make use of. For more information please visit the PetroFit [repo](https://github.com/PetroFit/petrofit/tree/main) or [documentation](https://petrofit.readthedocs.io/en/latest/).

cc @crawfordsm 