### PR TITLE
Add a role for security team

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -346,7 +346,7 @@
         "responsibilities": {
             "description": "Organize security reporting and auditing for packages in the project, including:",
             "details": [
-                "Monitor and reply to security reports (this role needs admin privileges on github to access reports submitted through github's secure reporting form)",
+                "Monitor and reply to security reports (this role needs admin privileges on GitHub to access reports submitted through GitHub's secure reporting form)",
                 "Coordinate the response to any security report with the relevant package maintainers and outside security experts",
                 "Coordinate security audits with external experts as needed and available",
                 "Release CVEs as necessary"

--- a/roles.json
+++ b/roles.json
@@ -334,6 +334,26 @@
         }
     },
     {
+        "role": "Security team",
+        "url": "security_team",
+        "people": [
+            "Hans Moritz G\u00fcnther",
+            "Pey Lian Lim",
+            "Thomas Robitaille",
+            "Erik Tollerud"
+        ],
+        "role-head": "Security team",
+        "responsibilities": {
+            "description": "Organize security reporting and auditing for packages in the project, including:",
+            "details": [
+                "Monitor and reply to security reports (this role needs admin privileges on github to access reports submitted through github's secure reporting form)",
+                "Coordinate the response to any security report with the relevant package maintainers and outside security experts",
+                "Coordinate security audits with external experts as needed and available",
+                "Release CVEs as necessary"
+            ]
+        }
+    },
+    {
         "role": "Core astropy package maintainer (general)",
         "url": "Core_package_general_maintainer",
         "people": [


### PR DESCRIPTION
While experience in software security would be a great benefit for this role, it is not strictly necessary. Instead, the main focus of this role is to keep track of incoming reports, decide whom to contact about it (relevant maintainers, outside experts, feedback from institutional users, etc.) and to organize the process of how to respond to software security issues.
I suggest to also give this team the power to conduct or initiate security audits, but I envision that that will only happen if outside expertize is available through some collaboration or grant.

Proposed people for the role:

* @hamogu 
* @pllim 
* @astrofrog 
* @eteq 