### PR TITLE
Update Coco member list as result of election

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -3,8 +3,8 @@
         "role": "Coordination committee member",
         "url": "Coordination_committee_member",
         "people": [
+            "Clara Brasseur",
             "Kelle Cruz",
-            "Hans Moritz G\u00fcnther",
             "Derek Homeier",
             "Pey Lian Lim",
             "Erik Tollerud"


### PR DESCRIPTION
The election is closed and our returns officer (Lindsay Stecher at NumFOCUS) has released the final results:
**Clara Brasseur 26**
**Erik Tollerud 22**
**27 cast votes (out of 43)**

Voting members can visit [heliosvoting](https://vote.heliosvoting.org/helios/e/67b9ef44-53ec-41c8-af96-8f5e40f014e1) with their user ID and password to verify the election results.

Both Clara and Erik have cleared the threshold of "50% of the votes" and are thus elected as new Coco members with terms running till fall of 2026.
Congratulations to both of them and thank you for taking on this important role in organizing and coordinating Astropy!