### PR TITLE
Remove affiliated package decisions from Coco

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -16,7 +16,6 @@
                 "details": [
 		            "Formally detailed in the <a href='https://github.com/astropy/astropy-APEs/blob/main/APE0.rst#the-coordination-committee'>The Astropy Project Governance Charter (APE 0)</a>",
                   "Keeping a large-scale view of the Astropy ecosystem",
-                  "Evaluating new affiliated package submissions and review of existing affiliated packages",
                   "Approving or rejecting Astropy APEs",
                   "Evaluating and merging core package pull requests as needed (e.g., for sub-packages without a maintainer)",
                    "Arbitrating disagreements in the core package, including final decisions when otherwise deadlocked",


### PR DESCRIPTION
The Coco has delegated this responsibility to dedicated affiliated package editors years ago, thus I suggest to not list is as Coco role at this stage.
In fact, we're about to pass that over to PyOpenSci and thus might not need the affiliated package editor role either in the near future, but that's for a future PR.