### PR TITLE
Added link to IOP Publishing "top cited paper" award 

### DIFF
--- a/team.html
+++ b/team.html
@@ -707,6 +707,7 @@
     <h2 id="awards">Awards<a class="paralink" href="#awards" title="Permalink to this headline">¶</a></h2>
     <p>
       <ul>
+        <li/><a href="https://accreditations.ioppublishing.org/9ce7a38e-8ef1-4aa3-86f4-5760022a1574#gs.0lk076">IOP Publishing Top Cited Paper Awards North America</a> (2023)
         <li/><a href="https://www.adass.org/softwareprize.html">ADASS Prize for an Outstanding Contribution to Astronomical Software</a> (2022)
         <li/><a href="https://ras.ac.uk/awards-and-grants/awards/2269-group-award-a">Royal Astronomical Society Group Award (Astronomy)</a> (2020)
       </ul>


### PR DESCRIPTION
The Astropy Collaboration was awarded an IOP Publishing "Top Cited Paper - North America" for having a paper in the top 1% of cited papers for 2020–2022.