### PR TITLE
Update package template

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -277,14 +277,13 @@
 
 	<h2 id="package-template">Package Template<a class="paralink" href="#package-template" title="Permalink to this headline">¶</a></h2>
 	<p>If you are considering creating a new astronomy package and would like it
-	to be an Astropy affiliated package, we provide a <a
-	href="https://github.com/astropy/package-template">package template</a> to
-	make it much easier to meet these standards. It provides the necessary
-	structure to generate documentation like that used in the astropy package, a
+	to be an Astropy affiliated package, you can use <a href="https://github.com/OpenAstronomy/packaging-guide">the OpenAstronomy packaging guide</a> to
+	make it much easier to meet these standards. It reflects up-to-date Python packaging techniques
+	to generate documentation like that used in the astropy package, a
 	ready-to-use testing framework, and a variety of tools that streamline tasks
 	like user configuration, caching downloaded files, or linking C-compiled
 	extensions. More details on this template are available in the <a
-	href="https://github.com/astropy/package-template/blob/main/README.rst">usage
+	href="https://packaging-guide.openastronomy.org/en/latest/#using-the-template">usage
 	instructions for the template</a>.
 	</p>
 <p>We recommend that you join the <a href="https://groups.google.com/forum/#!forum/astropy-affiliated-maintainers">astropy-affiliated-maintainers</a> mailing list to be kept informed of updates to the package template, as well as to have any dicussions related to setting up affiliated packages.</p>


### PR DESCRIPTION
The [Astropy package template](https://github.com/astropy/package-template) has been [deprecated](https://github.com/astropy/package-template#deprecation-warning) in favor of the OpenAstronomy packaging guide. 
This PR makes the documentation reflect that info.