### PR TITLE
MNT: Remove defunct CircleCI setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,3 @@ jobs:
       - store_artifacts:
           path: /root/project
           destination: html
-
-
-notify:
-  webhooks:
-    - url: https://giles.cadair.dev/circleci


### PR DESCRIPTION
This pull request is to remove defunct setup. I think I did the UI thing as documented in https://github.com/cadair/giles#circleci-artifact-links . We will see...

Fix #566

cc @Cadair 