### PR TITLE
Remove mention of LTS in navbar

### DIFF
--- a/about.html
+++ b/about.html
@@ -54,7 +54,6 @@
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
                                 <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
                             </ul>
                         </div>
                     </div>

--- a/acknowledging.html
+++ b/acknowledging.html
@@ -164,7 +164,6 @@ archivePrefix = {arXiv},
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-3.1.html
+++ b/announcements/release-3.1.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-3.2.html
+++ b/announcements/release-3.2.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-4.0.html
+++ b/announcements/release-4.0.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-4.1.html
+++ b/announcements/release-4.1.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-4.3.html
+++ b/announcements/release-4.3.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-5.0.html
+++ b/announcements/release-5.0.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-5.1.html
+++ b/announcements/release-5.1.html
@@ -50,7 +50,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-5.2.html
+++ b/announcements/release-5.2.html
@@ -50,7 +50,6 @@
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
                                 <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
                             </ul>
                         </div>
                     </div>

--- a/announcements/release-5.3.html
+++ b/announcements/release-5.3.html
@@ -50,7 +50,6 @@
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
                                 <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
                             </ul>
                         </div>
                     </div>

--- a/announcements/release-6.0.html
+++ b/announcements/release-6.0.html
@@ -50,7 +50,6 @@
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
                                 <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
                             </ul>
                         </div>
                     </div>

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -54,7 +54,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/contribute.html
+++ b/contribute.html
@@ -52,7 +52,6 @@
   <ul>
   <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
   <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-  <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
   </ul>
   </div>
   </div>

--- a/credits.html
+++ b/credits.html
@@ -54,7 +54,6 @@
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
                                 <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
                             </ul>
                         </div>
                     </div>

--- a/help.html
+++ b/help.html
@@ -51,7 +51,6 @@
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/history.html
+++ b/history.html
@@ -81,7 +81,6 @@ window.onload = function() {
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
                                 <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
                             </ul>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,6 @@ window.onload = function() {
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
 								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-								<li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
 							</ul>
 						</div>
 					</div>

--- a/team.html
+++ b/team.html
@@ -53,7 +53,6 @@
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
                                 <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
-                                <li><a href="https://astropy.readthedocs.io/en/lts/index.html" target="_blank">Long-Term Support</a></li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Fix https://github.com/astropy/astropy.github.com/issues/565

As per https://github.com/astropy/astropy-APEs/blob/main/APE21.rst