### PR TITLE
Nominate Moritz Affiliated Editor

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -227,7 +227,7 @@
     {
         "role": "Affiliated package review editor",
         "url": "Affiliated_package_review_editor",
-        "people": ["Derek Homeier", "William Jamieson"],
+        "people": ["Hans Moritz G\u00fcnther", "Derek Homeier"],
         "deputy": ["Unfilled"],
         "role-head": "Affiliated package review editor",
         "responsibilities": {


### PR DESCRIPTION
Following up on his own offer the Coco is nominating Hans-Moritz Günther as Affiliated Package editor to replace William, who is stepping down from this role (#576).
@hamogu has served in this role until the end of 2021; note that in the future both editors will work in a re-defined function under our partnership with the pyOpenSci review system as described in #574.
Pinging @ceb8