### PR TITLE
William Jamieson is stepping down from several roles

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -217,7 +217,7 @@
         },
         {
             "name": "asdf-astropy",
-            "maintainer": "William Jamieson, Brett Graham, Nadia Dencheva, and Perry Greenfield <wjamieson@stsci.edu>",
+            "maintainer": "Brett Graham, Nadia Dencheva, and Perry Greenfield <bgraham@stsci.edu>",
             "stable": true,
             "home_url": "https://asdf-astropy.readthedocs.io/en/latest/",
             "repo_url": "https://github.com/astropy/asdf-astropy",

--- a/roles.json
+++ b/roles.json
@@ -227,7 +227,7 @@
     {
         "role": "Affiliated package review editor",
         "url": "Affiliated_package_review_editor",
-        "people": ["Derek Homeier", "William Jamieson"],
+        "people": ["Derek Homeier"],
         "deputy": ["Unfilled"],
         "role-head": "Affiliated package review editor",
         "responsibilities": {
@@ -610,7 +610,7 @@
                 "people": [
                     "Nadia Dencheva",
                     "Perry Greenfield",
-                    "William Jamieson"
+                    "Brett Graham"
                 ]
             },
             {


### PR DESCRIPTION
I am stepping down from several of my rolls with the Astropy project. This is because I am moving away from working at STScI to working for a private company. Due to this change my time and ability to contribute to astropy will be much more limited. For now I believe that I can continue to act as an `astropy.modeling` maintainer as a volunteer in my personal time.