### PR TITLE
DOC: updating pyvo maintainer list

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -356,7 +356,7 @@
         },
         {
             "name": "PyVO",
-            "maintainer": "Christine Banek, Adrian Damian, Stefan Becker, and Tom Donaldson",
+            "maintainer": "Adrian Damian, Brigitta Sipőcz, Manon Marchand, Markus Demleitner, and Tom Donaldson",
             "stable": true,
             "home_url": "https://pyvo.readthedocs.io/",
             "repo_url": "https://github.com/astropy/pyvo",


### PR DESCRIPTION
To reflect reality. Accompanying task is to update the github team and revise the accesses to the repo (as it's currently a mixed of individuals rather than team-based)


cc @pllim 