### PR TITLE
Add strategic planning role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -55,6 +55,25 @@
         }
     },
     {
+        "role": "Strategic Planner",
+        "url": "strategic_planner",
+        "people": [
+            "All Coordination Committee Members"
+        ],
+        "role-head": "Strategic planner",
+        "responsibilities": {
+            "description": "Do long-term planning for the Astropy Project as a whole, including:",
+            "details": [
+                "Shape and provide a vision for next major steps in the Project, in consultation with the whole Astropy community.",
+                "Maintain a large-scale view of the project (both from developer and user perspectives).",
+                "Provide points of contact for external stakeholders on the above (with the CoCo).",
+                "Monitor efforts on the topic above to ensure they are being done as imagined.",
+                "Write grant proposals (with the Finance Committee).",
+                "Oversee the Astropy Project Roadmap."
+            ]
+        }
+    },
+    {
         "role": "Finance committee member",
         "url": "finance_committee_member",
         "people": [

--- a/roles.json
+++ b/roles.json
@@ -55,7 +55,7 @@
         }
     },
     {
-        "role": "Strategic Planner",
+        "role": "Strategic planning committee member",
         "url": "strategic_planner",
         "people": [
             "All Coordination Committee Members"
@@ -65,11 +65,12 @@
             "description": "Do long-term planning for the Astropy Project as a whole, including:",
             "details": [
                 "Shape and provide a vision for next major steps in the Project, in consultation with the whole Astropy community.",
-                "Maintain a large-scale view of the project (both from developer and user perspectives).",
+                "Maintain an overview of all the project activities (both from developer and user perspectives).",
                 "Provide points of contact for external stakeholders on the above (with the CoCo).",
-                "Monitor efforts on the topic above to ensure they are being done as imagined.",
-                "Write grant proposals (with the Finance Committee).",
-                "Oversee the Astropy Project Roadmap."
+                "Monitor project activities to see how well aligned with the roadmap and strategic goals of the project they are, and report back to the CoCo and community.",
+                "Coordinate writing grant proposals (in collaboration with the Finance Committee and wider community).",
+                "Maintain the Astropy Project Roadmap.",
+                "Engage with, and collect input from, the the whole Astropy Community on project vision and priorities."
             ]
         }
     },

--- a/roles.json
+++ b/roles.json
@@ -66,11 +66,11 @@
             "details": [
                 "Shape and provide a vision for next major steps in the Project, in consultation with the whole Astropy community.",
                 "Maintain an overview of all the project activities (both from developer and user perspectives).",
-                "Provide points of contact for external stakeholders on the above (with the CoCo).",
-                "Monitor project activities to see how well aligned with the roadmap and strategic goals of the project they are, and report back to the CoCo and community.",
-                "Coordinate writing grant proposals (in collaboration with the Finance Committee and wider community).",
+                "Provide points of contact for external stakeholders on the above (with the Coordination Committee).",
+                "Monitor project activities to see how well aligned they are with the roadmap and strategic goals of the project, and report back to the community and Coordination Committee.",
+                "Coordinate writing grant proposals (in collaboration with the Finance Committee, Coordination Committee, and community).",
                 "Maintain the Astropy Project Roadmap.",
-                "Engage with, and collect input from, the the whole Astropy Community on project vision and priorities."
+                "Engage with, and collect input from, the whole Astropy Community on project vision and priorities."
             ]
         }
     },


### PR DESCRIPTION
This came out of some discussions the CoCo has been having the last few months on whose role it is to do big picture planning.  We eventually settled on the reality of the current situation: that it has historically been something the CoCo does, but it is not *necessary* that this be so, and we should make it an explicit role so others can participate if they want.

As a starting point I named the people as just "the CoCo members" since that's the current reality, but that could change if others want to lean in on this topic.