### PR TITLE
Adding link to astropy policies document

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -28,7 +28,7 @@
             {
                 "description": "Organization and communication:",
                 "details": [
-                    "Policies: <a href='https: //github.com/astropy/astropy-project/tree/main/policies/coco-operating-policies.md'>CoCo Operating Policies</a>.",
+                    "Policies: <a href='https://github.com/astropy/astropy-project/tree/main/policies/coco-operating-policies.md'>CoCo Operating Policies</a>.",
                     "Meeting records: <a href='https://docs.google.com/document/d/1t7gEE6gIgNUCyObQFq3aYFMcOh4V4m27CNrxBGYwQuw/edit?usp=sharing'>CoCo Running Notes</a>.",
                     "Communication within the coordination committee happens through regular Zoom meetings and a private Slack channel.",
                     "Contact the Coordination Committee via email to <a href='mailto:coordinators@astropy.org'>coordinators@astropy.org</a> or by tagging the <a href='https://github.com/orgs/astropy/teams/coordinators'>github team @astropy/coordinators</a>.",

--- a/team.html
+++ b/team.html
@@ -120,6 +120,9 @@
 	activities.  In this section we list the responsibilities for each of
 	the identified project roles.  The list of people fulfilling these
 	roles is found in the <a href="#roles">Roles</a> section.
+        Committee/Team specific policies and communication methods are outlined in the
+        <a href="https://github.com/astropy/astropy-project/tree/main/policies#readme">Astropy Policies</a>
+        readme document.
         </p>
 
         <div id="roles-description"></div>


### PR DESCRIPTION
Adding a link from the Roles page to the astropy policies document in the astropy-project repo, per https://github.com/astropy/astropy-project/pull/400.

The edit to `roles.json` is unrelated, I just noticed that the link to the CoCo operating policies was dead, and discovered there was an errant space in the url.