### PR TITLE
Replace devdocs with direct RTD URL

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,7 +53,7 @@
                         <div class="dropdown-content">
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-                                <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+                                <li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
                             </ul>
                         </div>
                     </div>

--- a/acknowledging.html
+++ b/acknowledging.html
@@ -163,7 +163,7 @@ archivePrefix = {arXiv},
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="https://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-2.0.html
+++ b/announcements/release-2.0.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.2.2/index.html" target="_blank">v1.2.2</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.1.2/index.html" target="_blank">v1.1.2</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.0.13/index.html" target="_blank">v1.0.13</a></li>

--- a/announcements/release-3.0.html
+++ b/announcements/release-3.0.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.2.2/index.html" target="_blank">v1.2.2</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.1.2/index.html" target="_blank">v1.1.2</a></li>
 								<li><a href="https://astropy.readthedocs.io/en/v1.0.13/index.html" target="_blank">v1.0.13</a></li>

--- a/announcements/release-3.1.html
+++ b/announcements/release-3.1.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-3.2.html
+++ b/announcements/release-3.2.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-4.0.html
+++ b/announcements/release-4.0.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-4.1.html
+++ b/announcements/release-4.1.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-4.3.html
+++ b/announcements/release-4.3.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-5.0.html
+++ b/announcements/release-5.0.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-5.1.html
+++ b/announcements/release-5.1.html
@@ -49,7 +49,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/announcements/release-5.2.html
+++ b/announcements/release-5.2.html
@@ -49,7 +49,7 @@
                         <div class="dropdown-content">
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-                                <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+                                <li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
                             </ul>
                         </div>
                     </div>

--- a/announcements/release-5.3.html
+++ b/announcements/release-5.3.html
@@ -49,7 +49,7 @@
                         <div class="dropdown-content">
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-                                <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+                                <li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
                             </ul>
                         </div>
                     </div>

--- a/announcements/release-6.0.html
+++ b/announcements/release-6.0.html
@@ -49,7 +49,7 @@
                         <div class="dropdown-content">
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-                                <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+                                <li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
                             </ul>
                         </div>
                     </div>

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -53,7 +53,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/contribute.html
+++ b/contribute.html
@@ -51,7 +51,7 @@
   <div class="dropdown-content">
   <ul>
   <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-  <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+  <li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
   </ul>
   </div>
   </div>

--- a/credits.html
+++ b/credits.html
@@ -53,7 +53,7 @@
                         <div class="dropdown-content">
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-                                <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+                                <li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
                             </ul>
                         </div>
                     </div>

--- a/help.html
+++ b/help.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>

--- a/history.html
+++ b/history.html
@@ -80,7 +80,7 @@ window.onload = function() {
                         <div class="dropdown-content">
                             <ul>
                                 <li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-                                <li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+                                <li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
                             </ul>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@ window.onload = function() {
 						<div class="dropdown-content">
 							<ul>
 								<li><a href="http://docs.astropy.org" target="_blank">Current Release</a></li>
-								<li><a href="http://devdocs.astropy.org/" target="_blank">In Development</a></li>
+								<li><a href="https://astropy.readthedocs.io/en/latest/" target="_blank">In Development</a></li>
 							</ul>
 						</div>
 					</div>


### PR DESCRIPTION
Replace devdocs with direct RTD URL for developement docs.

HTTP is not secure and HTTPS for "devdocs" does not work.