### PR TITLE
Roles: Remove Madison Bray from DevOps

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -261,7 +261,6 @@
         "role": "DevOps and Operations Specialist",
         "url": "devops_team",
         "people": [
-            "E. Madison Bray",
             "Pey Lian Lim",
             "Brigitta Sip\u0151cz"
         ],


### PR DESCRIPTION
Madison has not been active for a while since the SOSS position lapsed and has not responded to developer surveys that we sent out. So I don't think this needs any 2-week periods nor debate? They are already listed under Lifetime Contributors (https://www.astropy.org/credits.html) for their extensive contributions prior.