### PR TITLE
Remove Nathaniel Starman from dev telecon role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -316,8 +316,7 @@
         "role": "Dev-telecon coordinator",
         "url": "devtelecon_coordinator",
         "people": [
-            "Hans Moritz G\u00fcnther",
-            "Nathaniel Starkman"
+            "Hans Moritz G\u00fcnther"
         ],
         "role-head": "Developer telecon coordinators",
         "responsibilities": {


### PR DESCRIPTION
In practice, Moritz has been hosting all the dev telecons lately. So I hereby propose we remove @nstarman from this role for now.