### PR TITLE
Roles: update photutils maintainers

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -569,8 +569,7 @@
             {
                 "role": "photutils",
                 "people": [
-                    "Larry Bradley",
-                    "Brigitta Sip\u0151cz"
+                    "Larry Bradley"
                 ]
             },
             {


### PR DESCRIPTION
@pllim pinged me to review roles in https://github.com/astropy/astropy.github.com/issues/519.  This PR removes @bsipocz as a `photutils` maintainer because she has not been active in that role in several years.

