### PR TITLE
Roles: update specutils maintainers

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -581,7 +581,6 @@
             {
                 "role": "specutils",
                 "people": [
-                    "Nicholas Earl",
                     "Adam Ginsburg",
                     "Ricky O'Steen",
                     "Erik Tollerud"


### PR DESCRIPTION
Removing Nick from the `specutils` maintainers list after speaking with him on Slack about it. 