### PR TITLE
Remove me from coordinates and utils maintainer role

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -412,7 +412,6 @@
                 "people": [
                     "Stuart Littlefair",
                     "Adrian Price-Whelan",
-                    "Erik Tollerud",
                     "Eero Vaher",
                     "Marten van Kerkwijk"
                 ]
@@ -518,8 +517,7 @@
                 "role": "astropy.utils",
                 "people": [
                     "Pey Lian Lim",
-                    "Brigitta Sip\u0151cz",
-                    "Erik Tollerud"
+                    "Brigitta Sip\u0151cz"
                 ]
             },
             {


### PR DESCRIPTION
This PR removes my name from the `coordinates` and `utils` maintainer roles.

Neither of these are due to a lack of desire, but a lack of time.  I have not been able to keep up with these as finance and CoCo workload has taken over, so I need to step down.  Honestly I probably should have done this years ago.

  I might try to ramp up again when my CoCo term expires, but time will tell :shrug: .