### PR TITLE
APE 22 listing: Adjust to upstream YAML changes

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -410,9 +410,21 @@ when you see them as options.</p>
 		   var info = "";
 		   for (var p=0; p<parsed.length; p++) {
 		      var package = parsed[p];
-		      if (package["partners"] == null || package["partners"].indexOf("astropy") == -1) {
-		      	  continue;
-		      }
+          var partners = package["partners"];
+          if (partners == null) {
+              continue;
+          }
+          var found_astropy = false;
+          for (var p2=0; p2<partners.length; p2++) {
+              var cur_partner = partners[p2];
+              if (cur_partner.startsWith("astropy")) {
+                  found_astropy = true;
+                  break;
+              }
+          }
+          if (!found_astropy) {
+              continue;
+          }
 
           namerow = tab.insertRow(i*4 + 1);
 


### PR DESCRIPTION
Looks like in https://raw.githubusercontent.com/pyOpenSci/pyopensci.github.io/main/_data/packages.yml they changed

```yaml
  partners:
    - 'astropy'
```

to

```yaml
  partners:
    - 'astropy: link-coming soon-to standards'
```

that caused our parser to fail and result in empty listing. I was expecting one or two packages. This is a follow-up of https://github.com/astropy/astropy.github.com/pull/590 .

xref https://github.com/pyOpenSci/pyosMeta/issues/186

cc @dhomeier and @hamogu 