### PR TITLE
APE 22 listing: Unsafe to assume PyPI name is the same as package name always

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -438,7 +438,7 @@ when you see them as options.</p>
           nmcell.setAttribute('width', 100)
           urlcell.innerHTML = url_translator(package["gh_meta"]["documentation"]);
           repocell.innerHTML = repo_translator(package["repository_link"]);
-          pypicell.innerHTML = pypi_translator(package["package_name"]);  // FIXME: https://github.com/pyOpenSci/pyopensci.github.io/issues/390
+          //pypicell.innerHTML = pypi_translator(package["package_name"]);  // FIXME: https://github.com/pyOpenSci/pyopensci.github.io/issues/390
 
           descrow = tab.insertRow(i*4 + 2);
           descrow.insertCell(0).innerHTML = "";


### PR DESCRIPTION
In the second post-APE 22 accepted package, we already run into problem that is related to https://github.com/pyOpenSci/pyopensci.github.io/issues/390 because https://github.com/kyleaoman/martini is published on PyPI as a different name https://pypi.org/project/astromartini/ while `martini` on PyPI is a completely separate package. Rather than trying to track this ourselves here, better to just disable PyPI field for now until this is fixed upstream.