### PR TITLE
Roles: Remove Ed Slavich from io.misc

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -436,8 +436,7 @@
             {
                 "role": "astropy.io.misc",
                 "people": [
-                    "Matteo Bachetti",
-                    "Ed Slavich"
+                    "Matteo Bachetti"
                 ]
             },
             {


### PR DESCRIPTION
@eslavich was added for `astropy.io.misc.asdf` but he should be removed now because:

1. `astropy.io.misc.asdf` is now `asdf-astropy` coordinated package with separate listing.
2. He no longer works at STScI who was paying him for this role.
3. He has not been active in the Project and did not respond to developer surveys.

xref https://github.com/astropy/astropy.github.com/issues/519