### PR TITLE
Roles: Move general maintainers in same section as sub-package maintainers

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -336,31 +336,19 @@
         }
     },
     {
-        "role": "Core astropy package maintainer (general)",
-        "url": "Core_package_general_maintainer",
-        "people": [
-            "Derek Homeier",
-            "Pey Lian Lim",
-            "Cl\u00e9ment Robert",
-            "Ole Streicher"
-        ],
-        "role-head": "Core astropy package maintainer (general)",
-        "responsibilities": {
-            "description": "Maintain the astropy core package in aspects that are not specific to a single sub-package",
-            "details": [
-                "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem, in particular for pull requests spanning multiple sub-packages",
-                "Merging Pull Requests that are non-controversial or after reaching out to relevant subpackage maintainers",
-                "Maintain, review, and advocate for useful interaction between multiple sub-packages",
-                "Perform initial triaging of issues and pull requests",
-                "Keeping track of frequent contributors and their relevant areas of expertise"
-            ]
-        }
-    },
-    {
-        "role": "Core astropy package maintainer (sub-package)",
+        "role": "Core astropy package maintainer",
         "url": "Subpackage_maintainer",
         "role-head": "Sub-package maintainer (at least one per core package sub-package)",
         "sub-roles": [
+            {
+                "role": "General",
+                "people": [
+                    "Derek Homeier",
+                    "Pey Lian Lim",
+                    "Cl\u00e9ment Robert",
+                    "Ole Streicher"
+                ]
+            },
             {
                 "role": "astropy.constants",
                 "people": [
@@ -504,16 +492,31 @@
                 ]
             }
         ],
-        "responsibilities": {
-            "description": "Maintain a sub-package of the astropy core package, including:",
-            "details": [
-                "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem",
-                "Merging Pull Requests in the sub-package",
-                "Keeping track of the \u201cbig picture\u201d progress of the sub-package - includes new feature development and significant bugs",
-                "Perform initial triaging of issues and pull requests",
-                "Keeping track of frequent contributors to the sub-package and their relevant areas of expertise"
-            ]
-        }
+        "responsibilities": [
+            {
+                "subrole-head": "General maintainer",
+                "description": "Maintain the astropy core package in aspects that are not specific to a single sub-package, including:",
+                "details": [
+                    "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem, in particular for pull requests spanning multiple sub-packages",
+                    "Merging Pull Requests that are non-controversial or after reaching out to relevant subpackage maintainers",
+                    "Maintain, review, and advocate for useful interaction between multiple sub-packages",
+                    "Perform initial triaging of issues and pull requests",
+                    "Keeping track of frequent contributors and their relevant areas of expertise"
+                ]
+            },
+            {
+
+                "subrole-head": "Sub-package maintainer",
+                "description": "Maintain a sub-package of the astropy core package, including:",
+                "details": [
+                    "Evaluating new pull requests for quality, API consistency, Astropy coding standards, and appropriateness within the overall astropy ecosystem",
+                    "Merging Pull Requests in the sub-package",
+                    "Keeping track of the \u201cbig picture\u201d progress of the sub-package - includes new feature development and significant bugs",
+                    "Perform initial triaging of issues and pull requests",
+                    "Keeping track of frequent contributors to the sub-package and their relevant areas of expertise"
+                ]
+            }
+        ]
     },
     {
         "role": "Coordinated package maintainer",


### PR DESCRIPTION
In https://github.com/astropy/astropy.github.com/pull/475 , there is no explanation why they couldn't be in the same section. Seems weird to have almost duplicate text as different rows. But is it allowed to have "sub-roles" and "responsibilities" not match?

https://output.circle-artifacts.com/output/job/e76af6f1-9bbd-4d0f-bb6f-02e3374ff603/artifacts/0/html/team.html

 xref https://github.com/astropy/astropy.github.com/issues/519