### PR TITLE
Roles: Sub-role in italics instead of bold

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,6 +24,10 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 
+em {
+  font-style: italic;
+}
+
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {

--- a/js/functions.js
+++ b/js/functions.js
@@ -125,7 +125,7 @@ $( document ).ready(function(){
                         if (index > 0) {
                             blocks += '<br>';
                         }
-                        blocks += '<strong>' + resp["subrole-head"] + '</strong>';
+                        blocks += '<em>' + resp["subrole-head"] + '</em>';
                     }
                     blocks += '<p>' + resp["description"] + '</p>' +
                               '<ul>' + detail_list + '</ul>';


### PR DESCRIPTION
Weird to have sub-role suddenly be bold font, and thus overshadowing other roles of similar status but just not sub-role.

https://output.circle-artifacts.com/output/job/8e1aeeef-348d-4532-810b-f2420c7a54a8/artifacts/0/html/team.html

xref https://github.com/astropy/astropy.github.com/issues/519