### PR TITLE
Astropy: 2025 Lancelot M. Berkeley–New York Community Trust Prize for Meritorious Work in Astronomy

### DIFF
--- a/team.html
+++ b/team.html
@@ -749,6 +749,7 @@
     <h2 id="awards">Awards<a class="paralink" href="#awards" title="Permalink to this headline">¶</a></h2>
     <p>
       <ul>
+        <li/><a href="https://aas.org/press/astropy-collaboration-receive-2025-berkeley-prize">Lancelot M. Berkeley–New York Community Trust Prize for Meritorious Work in Astronomy</a> (2025)
         <li/><a href="https://accreditations.ioppublishing.org/9ce7a38e-8ef1-4aa3-86f4-5760022a1574#gs.0lk076">IOP Publishing Top Cited Paper Awards North America</a> (2023)
         <li/><a href="https://www.adass.org/softwareprize.html">ADASS Prize for an Outstanding Contribution to Astronomical Software</a> (2022)
         <li/><a href="https://ras.ac.uk/awards-and-grants/awards/2269-group-award-a">Royal Astronomical Society Group Award (Astronomy)</a> (2020)


### PR DESCRIPTION
Related press releases:

* https://aas.org/press/astropy-collaboration-receive-2025-berkeley-prize
* https://www.stsci.edu/contents/news-releases/2024/news-2024-401

Preview: https://output.circle-artifacts.com/output/job/daacdd68-e195-44d1-a7a1-4eaf477e11f2/artifacts/0/html/team.html#awards

Congratulations, Astropy!