### PR TITLE
Feature Astropy Project awards more prominently

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,19 @@ window.onload = function() {
 		<a class="button" href="https://numfocus.org/donate-to-astropy" target="_blank">Donate to Astropy</a>
 	</section>
 
-	<section class="whatsnext">
+    <section>
+        <h1 id="awards">Awards<a class="paralink" href="#awards" title="Permalink to this headline">¶</a></h2>
+        <p>
+          <ul>
+            <li/><a href="https://aas.org/press/astropy-collaboration-receive-2025-berkeley-prize">Lancelot M. Berkeley–New York Community Trust Prize for Meritorious Work in Astronomy</a> (2025)
+            <li/><a href="https://accreditations.ioppublishing.org/9ce7a38e-8ef1-4aa3-86f4-5760022a1574#gs.0lk076">IOP Publishing Top Cited Paper Awards North America</a> (2023)
+            <li/><a href="https://www.adass.org/softwareprize.html">ADASS Prize for an Outstanding Contribution to Astronomical Software</a> (2022)
+            <li/><a href="https://ras.ac.uk/awards-and-grants/awards/2269-group-award-a">Royal Astronomical Society Group Award (Astronomy)</a> (2020)
+          </ul>
+        </p>
+      </section>
+
+    <section class="whatsnext">
 		<h1 id="zenodo">Zenodo community<a class="paralink" href="#szenodo-community" title="Permalink to this headline">¶</a></h1>
 		<p>Documents, notes from previous meetings, and talks about Astropy are collected in a Zenodo community for long-term archiving.
 		   Everyone is encouraged to submit talks, etc. and other relevant materials.

--- a/index.html
+++ b/index.html
@@ -115,6 +115,10 @@ window.onload = function() {
 
 </section>
 
+<section class="whatsnext">
+    <h1 id="news">Congratulations</h1> The Astropy Project has been awarded the <a href="https://aas.org/press/astropy-collaboration-receive-2025-berkeley-prize">Lancelot M. Berkeley–New York Community Trust Prize for Meritorious Work in Astronomy</a> for 2025!
+</section>
+
 	<section class="install">
 		<h1 id="install-astropy">Install Astropy<a class="paralink" href="#install-astropy" title="Permalink to this headline">¶</a></h1>
         There are a number of ways of installing the latest version of the astropy core package. If you normally use <code>pip</code> to install Python packages, you can do:

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ window.onload = function() {
 </section>
 
 <section class="whatsnext">
-    <h1 id="news">Congratulations</h1> The Astropy Project has been awarded the <a href="https://aas.org/press/astropy-collaboration-receive-2025-berkeley-prize">Lancelot M. Berkeley–New York Community Trust Prize for Meritorious Work in Astronomy</a> for 2025!
+    <h1 id="news">Congratulations to all Astropy contributors</h1> The Astropy Project has been awarded the <a href="https://aas.org/press/astropy-collaboration-receive-2025-berkeley-prize">Lancelot M. Berkeley–New York Community Trust Prize for Meritorious Work in Astronomy</a> for 2025!
 </section>
 
 	<section class="install">

--- a/team.html
+++ b/team.html
@@ -745,18 +745,6 @@
 
 	</section>
 
-  <section>
-    <h2 id="awards">Awards<a class="paralink" href="#awards" title="Permalink to this headline">¶</a></h2>
-    <p>
-      <ul>
-        <li/><a href="https://aas.org/press/astropy-collaboration-receive-2025-berkeley-prize">Lancelot M. Berkeley–New York Community Trust Prize for Meritorious Work in Astronomy</a> (2025)
-        <li/><a href="https://accreditations.ioppublishing.org/9ce7a38e-8ef1-4aa3-86f4-5760022a1574#gs.0lk076">IOP Publishing Top Cited Paper Awards North America</a> (2023)
-        <li/><a href="https://www.adass.org/softwareprize.html">ADASS Prize for an Outstanding Contribution to Astronomical Software</a> (2022)
-        <li/><a href="https://ras.ac.uk/awards-and-grants/awards/2269-group-award-a">Royal Astronomical Society Group Award (Astronomy)</a> (2020)
-      </ul>
-    </p>
-  </section>
-
 	<footer>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 		<script src="js/jquery.sidr.min.js"></script>


### PR DESCRIPTION
We should highlight the prestigious awards of the project on the main landing page instead of burying them deep on the team page.

In addition, let's shout about the AAS Award on the front page! We can plan to remove this banner in two or three months.