### PR TITLE
Remove question mark in What's new

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ window.onload = function() {
     </section>
 
 <section class="whatsnew"><div id="prenew"></div>
-	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/6.1.html">Astropy 6.1?</a>
+	What's new in <a href="http://docs.astropy.org/en/stable/whatsnew/6.1.html">Astropy 6.1</a>
 	<p class="version" id="core-package-version"></p>
 
 </section>


### PR DESCRIPTION
When I showed the `astropy.org` landing page to someone (for the new award stuff), their first comment was "Why is the astropy version number `"6.1?"`?  Don't they know the version number? I actually had the same feeling looking at this, since the question mark is in the same color due to being in the link reference.

One option is moving the question mark outside the link so it appears black, but I think that looks awkward. So this PR just removes it entirely, following the [example of Python](https://docs.python.org/3/whatsnew/index.html), like `What's new in Astropy 6.1` as a statement not a question.