### PR TITLE
Update description in lifetime contributors

### DIFF
--- a/credits.html
+++ b/credits.html
@@ -140,10 +140,13 @@
     recognized project.
 
     <h3 id="larry-bradley">Larry Bradley</h3>
-    Larry has served as the lead developer and maintainer of the Photutils
-    package (an Astropy coordinated package for source detection and photometry)
-    since 2014. He also is as a maintainer of the astropy regions package
-    and the astropy visualization, stats, and convolution subpackages.
+    Larry has been involved in the project since the fall of 2013.
+    Since 2014, he has served as the lead developer and maintainer of
+    the Photutils package, an Astropy coordinated package for source
+    detection, photometry, and related tools. He is also a developer
+    and maintainer of the Astropy visualization, stats, and convolution
+    packages and the Regions coordinated package. Larry has also served
+    as an instructor at Astropy workshops since 2016.
 
     <h3 id="madison-bray">Madison Bray</h3>
     Madison was a founding member of the Astropy project and was the main


### PR DESCRIPTION
This started as a PR to fix a typo ("He also is as a maintainer"), but I also reworded it a bit.