### PR TITLE
Add Clement Robert as general maintainer for Astropy core

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -341,6 +341,7 @@
         "people": [
             "Derek Homeier",
             "Pey Lian Lim",
+            "Cl\u00e9ment Robert",
             "Ole Streicher"
         ],
         "role-head": "Core astropy package maintainer (general)",


### PR DESCRIPTION
Adding @neutrinoceros in this role, to facilitate his work in his present position as research software engineer and beyond that.