### PR TITLE
Add Jeff Jennings to Learn

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -161,7 +161,8 @@
             "Matt Craig",
 		    "Adrian Price-Whelan",
 		    "Erik Tollerud",
-		    "Jonathan Sick"
+		    "Jonathan Sick",
+            "Jeff Jennings"
 		]
 	    },
 	    {


### PR DESCRIPTION
I am nominating @jeffjennings to join the Learn team. He is in the process of getting up to speed and fixing the broken infrastructure of the Learn Astropy website and will be a great addition to the team.