### PR TITLE
Remove duplicate Ed Slavich

### DIFF
--- a/team.html
+++ b/team.html
@@ -336,7 +336,6 @@
 			<li>E . Madison Bray</li>
 			<li>E . Rykoff</li>
 			<li>E.C. Herenz</li>
-			<li>Ed Slavich</li>
 			<li>Eduardo Olinto</li>
 			<li>Edward Betts</li>
 			<li>Edward Slavich</li>


### PR DESCRIPTION
Remove duplicate Ed Slavich because it is the same as Edward Slavich.

Pinging @astropy/astropy-project-release-team because I think this list is updated during releases?