### PR TITLE
Add Hannu Parviainen as specreduce maintainer

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -619,7 +619,8 @@
                     "Tim Pickering",
                     "Erik Tollerud",
                     "Kyle Conroy",
-                    "Clare Shanahan"
+                    "Clare Shanahan",
+                    "Hannu Parviainen"
                 ]
             }
         ],


### PR DESCRIPTION
@hpparvi was hired as Specreduce project manager, and has accepted the role as maintainer and started these duties, so I am adding him to the roles page as a maintainer. 