### PR TITLE
Update link to pyOpenSci partners page for Astropy

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -207,7 +207,7 @@
 here, with their Astropy filter applied. Waiting for resolution of
 https://github.com/pyOpenSci/software-peer-review/issues/268
 but for now just do a generic link to their listing. -->
-<p>All accepted pyOpenSci packages available <a href="https://www.pyopensci.org/python-packages.html">here</a>.</p>
+<p>All accepted pyOpenSci packages available <a href="https://www.pyopensci.org/communities/astropy.html">here</a>.</p>
 
 <p>All currently under review packages via pyOpenSci available <a href="https://github.com/pyOpenSci/software-submission/issues?q=is%3Aissue+is%3Aopen+label%3Aastropy">here</a>.</p>
 	</section>


### PR DESCRIPTION
Recently made possible by https://github.com/pyOpenSci/pyopensci.github.io/pull/207