### PR TITLE
Only parse roles.json on Team page + other fixes

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -190,11 +190,9 @@
 		</tr>
 		</thead>
 		<tbody valign="top">
-		<tr class="row-even"><td rowspan="1">Loading...</td>
-		<td rowspan="1">&nbsp;</td>
-		<td rowspan="1">&nbsp;</td>
-		<td rowspan="1">&nbsp;</td>
-		<td rowspan="1">&nbsp;</td>
+		<tr class="row-even">
+		<td colspan="1">&nbsp;</td>
+		<td colspan="3">&nbsp;</td>
 		</tr>
 		<tr class="row-odd">
 		<td colspan="1">&nbsp;</td>
@@ -403,9 +401,7 @@ when you see them as options.</p>
 		   var parsed = yaml.parse(yamlString);
 		   var i = 0;
 
-       // We have to delete the "Loading..." row
        var tab = document.getElementById("pyos-package-table");
-       tab.deleteRow(1);
 
 		   var info = "";
 		   for (var p=0; p<parsed.length; p++) {

--- a/getteam.py
+++ b/getteam.py
@@ -5,7 +5,6 @@ reflect the  current ``credits.rst`` file from the astropy repository.
 Note that this first looks for the ``ASTROPY_REPO_PATH`` environment
 variable to try to find a local copy of the astropy repo.
 """
-from __future__ import print_function
 
 
 def get_astropy_credits(warner=print):

--- a/history.html
+++ b/history.html
@@ -16,35 +16,6 @@
 <!-- Google analytics -->
 <script src="js/analytics.js"></script>
 
-<!-- Meow woof -->
-<script>
-window.onload = function() {
-
-  $.getJSON('https://pypi.org/pypi/astropy/json', function(data) {
-    document.getElementById('core-package-version').innerHTML = 'Current Version: ' + data.info.version;
-  });
-
-
-  var today = new Date();
-  var month = today.getMonth() + 1;
-  var date = today.getDate();
-
-  if (month == 4 && date == 1) {
-    $('#hero img').attr('src', 'images/astropy_meow.png');
-    $('#hero img').attr('onerror', 'this.src=\x27images/astropy_meow.png\x27; this.onerror=null;');
-
-    var dogeContainer = document.getElementById("prenew");
-    var dogeImg = document.createElement("img");
-    dogeImg.onload=function() {
-      dogeContainer.appendChild(dogeImg);
-    }
-    dogeImg.src = 'images/astropy_doge.png';
-    dogeImg.alt = 'wow so open very python';
-  }
-
-};
-</script>
-
 </head>
 
 <body>

--- a/js/functions.js
+++ b/js/functions.js
@@ -22,123 +22,6 @@ $( document ).ready(function(){
 			$(this).removeClass("subhover"); //On hover out, remove class "subhover"
 	});
 
-    //creating Astropy roles table & roles lists using roles.json
-    var request = new XMLHttpRequest();
-    var dataURL = "roles.json";
-    request.open('GET', dataURL);
-    request.responseType = 'json';
-    request.send();
-
-    //log error when request gets failed
-    request.onerror = function () {
-        console.log("XHR error");
-    };
-
-    request.onload = function () {
-        //received json data via XHR
-        var data = request.response;
-        //creating roles table from json data
-        createRolesTable(data);
-        //creating roles lists from json data
-        createRolesDescription(data);
-    };
-
-    function createRolesTable(roles) {
-        //roles is an array of objects called "role"
-        var rows = '';
-        roles.forEach(function (role) {
-            //role is an object containing information about each team role
-            //index marks current people
-            var index = 0;
-
-            // for roles where there are no sub-roles, the people are defined
-            // at the top-level of the JSON role dict - for convenience below we create
-            // a virtual sub-role with no heading
-            if (!('sub-roles' in role)) {
-                role['sub-roles'] = [{'role': '',
-                                      'people': role['people']}];
-            }
-
-            //creating each row by iterating over each person in a role
-            role["sub-roles"].forEach(function (subrole) {
-                //rowRole is displayed once for each role
-                rowRole = index == 0 ? '<a href="#' + role["url"] + '">' + role["role"] + '</a>' : "";
-
-                var rowSubRole = subrole['role'];
-
-                if (subrole['people'][0] == "Unfilled") {
-                    rowPeople = '<a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a>';
-                } else {
-                    rowPeople = subrole['people'].join(', ');
-                }
-
-                //generating rows
-                if (index == 0) {
-                    rows += '<tr class="border-top">';
-                } else {
-                    rows += '<tr>';
-                }
-
-                rows +=   '<td>' + rowRole + '</td>' +
-                          '<td>' + rowSubRole + '</td>' +
-                          '<td>' + rowPeople + '</td>' +
-                        '</tr>';
-                index++;
-            });
-        });
-
-        $("#roles-table").append(rows);
-    }
-
-    function createRolesDescription(roles) {
-        //roles is an array of objects called "role"
-        var blocks = "";
-        roles.forEach(function (role) {
-            //role is an object containing information about each team role
-            var list = "";
-            //checking if role["description"] array isn't empty
-            if (role["responsibilities"] != null) {
-
-                // If responsibilities is a dict, wrap inside a list so that all entries have a list
-                // dicts
-                if (role['responsibilities'].constructor == Object) {
-                    role['responsibilities'] = [role['responsibilities']];
-                }
-
-                console.log(role['responsibilities']);
-
-                blocks += '<br/>' +
-                '<h3 id="' + role["url"] + '">' + role["role-head"] + '</h3>';
-
-                index = 0;
-
-                role['responsibilities'].forEach(function (resp) {
-
-                    console.log(resp);
-
-                    detail_list = '';
-                    resp["details"].forEach(function (detail) {
-                        detail_list += '<li>' + detail + '</li>';
-                    });
-
-                    if ('subrole-head' in resp) {
-                        if (index > 0) {
-                            blocks += '<br>';
-                        }
-                        blocks += '<em>' + resp["subrole-head"] + '</em>';
-                    }
-                    blocks += '<p>' + resp["description"] + '</p>' +
-                              '<ul>' + detail_list + '</ul>';
-
-                    index += 1;
-
-                })
-
-            }
-        });
-        $("#roles-description").append(blocks);
-    }
-
     $('#os-selector ul').each(function(){
       // For each set of tabs, we want to keep track of
       // which tab is active and it's associated content
@@ -255,6 +138,7 @@ function pypi_translator(pypiname) {
     }
 }
 
+
 function bool_translator(stable) {
     if (stable) {
         return 'Yes';
@@ -262,6 +146,7 @@ function bool_translator(stable) {
         return 'No';
     }
 }
+
 
 function ghuser_translator(fullname, ghname) {
     if (fullname === undefined || ghname === undefined) {
@@ -271,6 +156,7 @@ function ghuser_translator(fullname, ghname) {
         return '<a href="' + urltext + '">' + fullname + '</a>';
     }
 }
+
 
 var _email_regex_str = '[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}';
 var _email_regex  = new RegExp(_email_regex_str, 'i');
@@ -292,10 +178,117 @@ function maintainer_translator(maint, pkgnm) {
 }
 
 
+function createRolesTable(roles) {
+    //roles is an array of objects called "role"
+    var rows = '';
+    roles.forEach(function (role) {
+        //role is an object containing information about each team role
+        //index marks current people
+        var index = 0;
+
+        // for roles where there are no sub-roles, the people are defined
+        // at the top-level of the JSON role dict - for convenience below we create
+        // a virtual sub-role with no heading
+        if (!('sub-roles' in role)) {
+            role['sub-roles'] = [{'role': '',
+                                  'people': role['people']}];
+        }
+
+        //creating each row by iterating over each person in a role
+        role["sub-roles"].forEach(function (subrole) {
+            //rowRole is displayed once for each role
+            rowRole = index == 0 ? '<a href="#' + role["url"] + '">' + role["role"] + '</a>' : "";
+
+            var rowSubRole = subrole['role'];
+
+            if (subrole['people'][0] == "Unfilled") {
+                rowPeople = '<a href="mailto:coordinators@astropy.org"><span style="font-style: italic;">Unfilled</span></a>';
+            } else {
+                rowPeople = subrole['people'].join(', ');
+            }
+
+            //generating rows
+            if (index == 0) {
+                rows += '<tr class="border-top">';
+            } else {
+                rows += '<tr>';
+            }
+
+            rows +=   '<td>' + rowRole + '</td>' +
+                      '<td>' + rowSubRole + '</td>' +
+                      '<td>' + rowPeople + '</td>' +
+                    '</tr>';
+            index++;
+        });
+    });
+
+    $("#roles-table").append(rows);
+}
+
+
+function createRolesDescription(roles) {
+    //roles is an array of objects called "role"
+    var blocks = "";
+    roles.forEach(function (role) {
+        //role is an object containing information about each team role
+        var list = "";
+        //checking if role["description"] array isn't empty
+        if (role["responsibilities"] != null) {
+
+            // If responsibilities is a dict, wrap inside a list so that all entries have a list
+            // dicts
+            if (role['responsibilities'].constructor == Object) {
+                role['responsibilities'] = [role['responsibilities']];
+            }
+
+            console.log(role['responsibilities']);
+
+            blocks += '<br/>' +
+            '<h3 id="' + role["url"] + '">' + role["role-head"] + '</h3>';
+
+            index = 0;
+
+            role['responsibilities'].forEach(function (resp) {
+
+                console.log(resp);
+
+                detail_list = '';
+                resp["details"].forEach(function (detail) {
+                    detail_list += '<li>' + detail + '</li>';
+                });
+
+                if ('subrole-head' in resp) {
+                    if (index > 0) {
+                        blocks += '<br>';
+                    }
+                    blocks += '<em>' + resp["subrole-head"] + '</em>';
+                }
+                blocks += '<p>' + resp["description"] + '</p>' +
+                          '<ul>' + detail_list + '</ul>';
+
+                index += 1;
+
+            })
+
+        }
+    });
+    $("#roles-description").append(blocks);
+}
+
+
+function populateRoles(data, tstat, xhr) {
+    //creating roles table from json data
+    createRolesTable(data);
+    //creating roles lists from json data
+    createRolesDescription(data);
+}
+
+
 function populateTables(data, tstat, xhr) {
     populatePackageTable('coordinated', filter_pkg_data(data, "coordinated", true));
     populatePackageTable('affiliated', filter_pkg_data(data, "coordinated", false));
 }
+
 
 function filter_pkg_data(data, field, value) {
     if (data === null) {
@@ -401,6 +394,7 @@ var review_color_map = {'Unmaintained': "red",
     "Needs work": "red"
 };
 
+
 function makeShields(pkg) {
   var shield_string = "";
 
@@ -425,6 +419,7 @@ function makeShields(pkg) {
   }
   return shield_string
 }
+
 
 function guess_os() {
     var OSName="source";

--- a/js/functions.js
+++ b/js/functions.js
@@ -241,7 +241,7 @@ function createRolesDescription(roles) {
                 role['responsibilities'] = [role['responsibilities']];
             }
 
-            console.log(role['responsibilities']);
+            //console.log(role['responsibilities']);
 
             blocks += '<br/>' +
             '<h3 id="' + role["url"] + '">' + role["role-head"] + '</h3>';
@@ -250,7 +250,7 @@ function createRolesDescription(roles) {
 
             role['responsibilities'].forEach(function (resp) {
 
-                console.log(resp);
+                //console.log(resp);
 
                 detail_list = '';
                 resp["details"].forEach(function (detail) {
@@ -401,7 +401,7 @@ function makeShields(pkg) {
   var key, shield_name, pkgvalue, color, url;
 
   for (key in review_name_map) {
-    console.log("K"+key);
+    //console.log("K"+key);
     if (review_name_map.hasOwnProperty(key)) {
       shield_name = review_name_map[key];
       if ("review" in pkg && key in pkg.review ) {

--- a/team.html
+++ b/team.html
@@ -750,6 +750,12 @@
 		<script src="js/jquery.sidr.min.js"></script>
 		<script src="js/functions.js"></script>
 
+	  <script type="text/javascript">
+		    $(document).ready(function() {
+		        $.getJSON("roles.json", populateRoles);
+		    });
+		</script>
+
         <hr>
 		<p>
 		<img style="vertical-align:middle" src="images/astropy_brandmark.png" height=20><span style="vertical-align:middle">


### PR DESCRIPTION
Seems like every page is trying to read `roles.json`. This even results in error in console log because `affiliated/index.html` cannot find `roles.json` in its own directory. Really only the Team page should be parsing `roles.json`.

Also fix #642 

And fix an error on History page (lol).