### PR TITLE
BUG: Fix IndexError in pyos insertRow

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -415,7 +415,7 @@ when you see them as options.</p>
               continue;
           }
 
-          namerow = tab.insertRow(i*4 + 1);
+          namerow = tab.insertRow(-1);
 
           nmcell = namerow.insertCell(0);
           urlcell = namerow.insertCell(1);
@@ -429,7 +429,7 @@ when you see them as options.</p>
           repocell.innerHTML = repo_translator(package["repository_link"]);
           //pypicell.innerHTML = pypi_translator(package["package_name"]);  // FIXME: https://github.com/pyOpenSci/pyopensci.github.io/issues/390
 
-          descrow = tab.insertRow(i*4 + 2);
+          descrow = tab.insertRow(-1);
           descrow.insertCell(0).innerHTML = "";
           desccell = descrow.insertCell(1);
           desccell.colSpan = "3";
@@ -444,7 +444,7 @@ when you see them as options.</p>
 		        }
 		      } 
 
-          maintrow = tab.insertRow(i*4 + 3);
+          maintrow = tab.insertRow(-1);
           maintrow.insertCell(0).innerHTML = "";
           maintcell = maintrow.insertCell(1);
           maintcell.colSpan = "3";

--- a/js/functions.js
+++ b/js/functions.js
@@ -153,6 +153,9 @@ function ghuser_translator(fullname, ghname) {
         return 'None';
     } else {
         var urltext = 'https://github.com/' + ghname;
+        if (fullname === null) {
+            fullname = ghname;
+        }
         return '<a href="' + urltext + '">' + fullname + '</a>';
     }
 }


### PR DESCRIPTION
Having a 4th package (congrats) via our pyOpenSci partnership broke the parser with IndexError. Not sure why index math worked for the old listing but not for the new one. Just using `-1` to append should be good enough.