### PR TITLE
Add banner for survey announcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,11 @@ window.onload = function() {
 
 </section>
 
+<section class="whatsnext">
+    	<h1 id="news">Astropy User Survey open until April 1</h1> 
+    The Astropy Project is running its first <a href="https://forms.gle/KX2cNuFsQYgVhF178">user survey</a>. Contribute your input by April 1!
+</section>
+	
 	<section class="install">
 		<h1 id="install-astropy">Install Astropy<a class="paralink" href="#install-astropy" title="Permalink to this headline">¶</a></h1>
         There are a number of ways of installing the latest release of the astropy core package. If you normally use <code>pip</code> to install Python packages, you can do:


### PR DESCRIPTION
This PR adds a banner (like the recent one for 10k citations to Astropy paper I) that advertises the astropy user survey, which will close on April 1. I should've thought of adding this banner sooner, but I'm hoping to get this merged quickly, as the survey just opened. Thanks!