### PR TITLE
pyOpenSci affiliated package listing: Use labels instead of partners field

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -409,7 +409,7 @@ when you see them as options.</p>
 		   var info = "";
 		   for (var p=0; p<parsed.length; p++) {
 		      var package = parsed[p];
-          var partners = package["partners"];
+          var partners = package["labels"];
           if (partners == null) {
               continue;
           }


### PR DESCRIPTION
As suggested in https://github.com/astropy/astropy.github.com/pull/550#issuecomment-2695927891 . Also see:

* https://github.com/pyOpenSci/pyopensci.github.io/pull/576