### PR TITLE
Update google analytics measurement ID

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -3,7 +3,7 @@
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-ga('create', 'UA-30968842-1', 'auto');
+ga('create', 'G-R0510VK4B6', 'auto');
 ga('require', 'displayfeatures');
 ga('require', 'linkid', 'linkid.js');
 ga('send', 'pageview');


### PR DESCRIPTION
For the current website analytics, Google analytics suggests updating the old measurement ID to a new format because "Legacy UA tags with connected site tags could lead to inconsistent data reports". This PR updates the measurement ID from "UA-*" to the new identifier. I've verified that it is not an issue for the measurement ID to be public, as it has been.