### PR TITLE
Remove defunct example gallery from Learn section

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,9 +125,8 @@ window.onload = function() {
 
 	<section class="whatsnext">
 		<h1 id="learn-astropy">Learn Astropy<a class="paralink" href="#learn-astropy" title="Permalink to this headline">¶</a></h1>
-		<p>You can explore the functionality available in Astropy by checking out the <a href="https://docs.astropy.org/en/stable/generated/examples/">Example Gallery, <a href="http://tutorials.astropy.org">Tutorials</a>, and <a
+		<p>You can explore the functionality available in Astropy by checking out the <a href="http://tutorials.astropy.org">Tutorials</a> and <a
 		href="https://docs.astropy.org">Documentation</a>.</p>
-		<a class="button" href="https://docs.astropy.org/en/stable/generated/examples/index.html" target="_blank">Example Gallery</a>
 		<a class="button" href="http://www.astropy.org/astropy-tutorials/" target="_blank">Tutorials</a>
 		<a class="button" href="https://docs.astropy.org/en/stable/index.html" target="_blank">Documentation</a>
 	</section>


### PR DESCRIPTION
Example gallery in core lib never really took off, so it was removed. The link will be broken when astropy v7.1 is released.

* astropy/astropy#17270 
* astropy/astropy#16194 