### PR TITLE
Add chair role to the finance committee

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -82,7 +82,7 @@
         "role": "Finance committee member",
         "url": "finance_committee_member",
         "people": [
-            "Kelle Cruz",
+            "Kelle Cruz (chair)",
             "Aarya Patil",
             "John Swinbank",
             "Erik Tollerud"


### PR DESCRIPTION
This PR is to name the chair of the finance committee following the policy change proposed in [PR#467](https://github.com/astropy/astropy-project/pull/467).