### PR TITLE
Changing inactive voting members to emeritus status

### DIFF
--- a/team.html
+++ b/team.html
@@ -142,15 +142,12 @@
       <li>Larry Bradley</li>
       <li>Clara Brasseur</li>
       <li>Michael K. Brewer</li>
-      <li>E. Madison Bray</li>
-      <li>Juan Luis Cano Rodríguez</li>
       <li>Mihai Cara</li>
       <li>Simon Conseil</li>
       <li>Lia Corrales</li>
       <li>Matt Craig</li>
       <li>Kelle Cruz</li>
       <li>Nadia Dencheva</li>
-      <li>Michael Droettboom</li>
       <li>Nicholas Earl</li>
       <li>Tom Donaldson</li>
       <li>Wilfred Gee</li>
@@ -182,15 +179,18 @@
       <li>James Turner</li>
       <li>Marten van Kerkwijk</li>
       <li>Eero Vaher</li>
-      <li>Zé Vinícius</li>
       <li>Benjamin Alan Weaver</li>
     </ul>
 
     <h3 id="votingmembers-emeritus">Emeritus Voting Members<a class="paralink" href="#votingmembers-emeritus" title="Permalink to this headline">¶</a></h3>
     <ul class="team">
+      <li>E. Madison Bray</li>
+      <li>Juan Luis Cano Rodríguez</li>
       <li>Steve Crawford</li>
+      <li>Michael Droettboom</li>
       <li>Michael Seifert</li>
       <li>Edward Slavich</li>
+      <li>Zé Vinícius</li>
     </ul>
     </p>
 


### PR DESCRIPTION
The PR changes the following 4 voting members to emeritus status:
- E. Madison Bray
- Michael Droettboom
- Zé Vinícius
- Juan Luis Cano Rodríguez

All new emeritus members have been contacted and agreed to the change in status.

