### PR TITLE
Remove packages that went through PyOpenSci from our old listing

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -675,7 +675,6 @@
                 "last-updated": "2017-11-08"
             }
         },
-
         {
             "name": "Halotools",
             "maintainer": "Andrew Hearin, Nick van Alfen <ahearin@nal.gov>",

--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -1,24 +1,5 @@
 {
     "packages": [
-        {
-            "name": "ZodiPy",
-            "maintainer": "Metin San <metin.san@astro.uio.no>",
-            "stable": true,
-            "home_url": "https://cosmoglobe.github.io/zodipy/",
-            "repo_url": "https://github.com/cosmoglobe/zodipy/",
-            "pypi_name": "zodipy",
-            "description": "ZodiPy is a Python tool for simulating the zodiacal emission that a solar system observer sees, either in the form of timestreams or binned HEALPix maps.",
-            "coordinated": false,
-            "review": {
-               "functionality": "Specialized package",
-               "ecointegration": "Partial",
-               "documentation": "Good",
-               "testing": "Good",
-               "devstatus": "Good",
-               "python3": "Yes",
-               "last-updated": "2024-02-24"
-            }
-          },
           {
           "name": "regularizePSF",
           "maintainer": "Marcus Hughes <marcus.hughes@swri.org>",
@@ -694,26 +675,7 @@
                 "last-updated": "2017-11-08"
             }
         },
-        {
-            "name": "stingray",
-            "maintainer": "Daniela Huppenkothen, Matteo Bachetti, Abigail Stevens, Simone Migliari, and Paul Balm",
-            "stable": false,
-            "repo_url": "https://github.com/StingraySoftware/stingray",
-            "home_url": "https://stingraysoftware.github.io",
-            "pypi_name": "stingray",
-            "description": "Python library for spectral-timing analysis of X-ray data.",
-            "image": null,
-            "coordinated": false,
-            "review": {
-                "functionality": "Specialized package",
-                "ecointegration": "Partial",
-                "documentation": "Partial",
-                "testing": "Good",
-                "devstatus": "Good",
-                "python3": "Yes",
-                "last-updated": "2017-11-08"
-            }
-        },
+
         {
             "name": "Halotools",
             "maintainer": "Andrew Hearin, Nick van Alfen <ahearin@nal.gov>",


### PR DESCRIPTION
Since the packges are now listed through PyOpenSci, they appear twice on the Astropy affiliated website once under the heading "Affiliated Packages Registry" and once under the heading "Affiliated Packages Registry (Pre-APE 22)".

We're trying to make that list the most useful for people to find packages and we think it's clearer if each package is listed only once. Thus, this PR removes the older (pre-APE 22) listing towards the bottom on the page.

Both affected packages have been contacted and agree:

https://github.com/StingraySoftware/stingray/issues/926
https://github.com/Cosmoglobe/zodipy/issues/50