### PR TITLE
Remove saba from the list of affiliated packages

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -915,25 +915,6 @@
            }
        },
        {
-          "name": "Saba",
-          "maintainer": "Michele Costa <m.t.costa@keele.ac.uk>",
-          "stable": true,
-          "repo_url": "https://github.com/astropy/saba",
-          "home_url": "https://saba.readthedocs.io",
-          "pypi_name": "saba",
-          "description": "A Package which allows astropy.modeling to interface with sherpa's fitting routines",
-          "coordinated": false,
-          "review": {
-            "functionality": "General package",
-              "ecointegration": "Good",
-              "documentation": "Good",
-              "testing": "Good",
-              "devstatus": "Functional but low activity",
-              "python3": "Yes",
-              "last-updated": "2017-09-26"
-          }
-       },
-       {
             "name": "dust_extinction",
             "maintainer": "Karl Gordon",
             "stable": false,


### PR DESCRIPTION
While the registry still lists the main original author as maintainer, he has left astronomy several years ago and I agreed to take over, though I have never done anything to get saba back to a functioning state or maintain it in any way.

As it stands, saba is old, unmaintained and doesn’t actually work for anything newer than astropy 1.0 or so (because astropy.modelling has been changing so much).
I think there are better alternatives to get more fitting algorithms into astropy by now (e.g. optimagic ) and realistically, I’m not going to pick up saba again - I’d rather spend energy to keep Sherpa itself running or bridge astropy.modelling to optimagic. I suggest we archive saba and remove it from the affiliated package list. It never gained much traction so the risk that people need it to be listed there for help with their pre-astropy 2.0 fitting is vanishingly low.

I request this removal as current acting maintainer of saba and I have received confirmation from the other original author who is still active in the Astropy project (@taldcroft) that he agrees.