### PR TITLE
Return a link to the description of badges

### DIFF
--- a/affiliated/index.html
+++ b/affiliated/index.html
@@ -215,7 +215,16 @@ but for now just do a generic link to their listing. -->
 
 <p>This section contains the listing of Astropy Affiliated Packages that pre-dated
 	<a href="https://github.com/astropy/astropy-APEs/blob/main/APE22.rst">APE 22</a>.
-This section is frozen as of March 6, 2024.</p>
+No new packages are be added to this list after March 6, 2024; but packages can be removed or their
+status can change.</p>
+<p>A detailed description of the meaning of the badges for each package can be found
+	<a href="https://github.com/astropy/astropy-project/blob/a9ea09ccd27703ea3ef2a80a811a5f70f91bc94b/affiliated/affiliated_package_review_guidelines.md#development-status-devstatus">here</a>.
+	Note in particular that a development status of
+	<img src="https://img.shields.io/badge/Functional%20but%20unmaintained-orange.svg" alt="Functional but unmaintained"> or
+	<img src="https://img.shields.io/badge/Functional%20but%20low%20activity-orange.svg" alt="Functional but low activity">
+	might be perfectly fine for e.g. teaching or with older Python verions, but packages with this status might not be
+	compatible with the latest versions of Astropy or might not reply to issues or bug reports.
+</p
 
     <p>Total number of pre-APE 22 affiliated packages: <strong id="total-affiliated-pkgs"></strong></p>
 


### PR DESCRIPTION
This change is the result of discussions as the Astropy 2025 coordination meeting and between the current Astropy affiliated package editors.

On the one hand, we want to provide users a quick way to find high-quality, integrated packages that are useful for their projects; on the other hand, we recognize that users have different needs. Some need packages compatible with cutting-edge versions, other need stable packages that don't require updating, e.g. teaching materials with every new release of astropy or numpy.
The text here tries to capture that in a few words as possible.

Suggestions for better wording are welcome.