### PR TITLE
Update learn link

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,9 +125,9 @@ window.onload = function() {
 
 	<section class="whatsnext">
 		<h1 id="learn-astropy">Learn Astropy<a class="paralink" href="#learn-astropy" title="Permalink to this headline">¶</a></h1>
-		<p>You can explore the functionality available in Astropy by checking out the <a href="http://tutorials.astropy.org">Tutorials</a> and <a
+		<p>You can explore the functionality available in Astropy by checking out the <a href="https://learn.astropy.org/">Tutorials</a> and <a
 		href="https://docs.astropy.org">Documentation</a>.</p>
-		<a class="button" href="http://www.astropy.org/astropy-tutorials/" target="_blank">Tutorials</a>
+		<a class="button" href="https://learn.astropy.org/" target="_blank">Tutorials</a>
 		<a class="button" href="https://docs.astropy.org/en/stable/index.html" target="_blank">Documentation</a>
 	</section>
 

--- a/roles.json
+++ b/roles.json
@@ -236,7 +236,7 @@
 	    },
 	    {
                 "subrole-head": "Learn content and infrastructure",
-                "description": "Maintain the infrastructure and edit content of the <a href='https://www.astropy.org/astropy-tutorials/'>Tutorials website</a>, including:",
+                "description": "Maintain the infrastructure and edit content of the <a href='https://learn.astropy.org/'>Tutorials website</a>, including:",
                 "details": [
                     "Facilitating the display and discoverability of the tutorials",
                     "Rendering of the Jupyter notebooks",


### PR DESCRIPTION
Updates the hyperlinks to the Learn site, as they were broken at https://www.astropy.org/ and https://www.astropy.org/team.html. 

Fix #666 