### PR TITLE
Link to Coordinated Packages listing from maintainer roles' description

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -648,7 +648,7 @@
             }
         ],
         "responsibilities": {
-            "description": "Maintain an astropy coordinated package, including:",
+            "description": "Maintain an <a href='https://www.astropy.org/affiliated/index.html#coordinated-package-list'>astropy coordinated package</a>, including:",
             "details": [
                 "Maintaining the github repository for the coordinated package",
                 "Maintaining the coordinated package's infrastructure (usually via the helpers and package template)",


### PR DESCRIPTION
This PR is adding a link to the full list of [Coordinated Packages](https://output.circle-artifacts.com/output/job/a14b8813-c010-4936-a08a-d8c4d83fe692/artifacts/0/html/affiliated/index.html#coordinated-package-list) in the section of the maintainer's [roles description](https://output.circle-artifacts.com/output/job/a14b8813-c010-4936-a08a-d8c4d83fe692/artifacts/0/html/team.html#Coordinated_package_maintainer), making it easier to find the full info of the packages including their contact info from the `Team` page.
This should also allow easier checks of the `roles.json` and `registry.json` content matches.