### PR TITLE
Add APE Editors

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -276,10 +276,10 @@
         "url": "APE_editor",
         "people": [
             "Clara Brasseur",
-            "Derek Homeier",
-            "Pey Lian Lim",
             "Aarya Patil",
-            "Erik Tollerud"
+			"Nathaniel Starkman",
+            "Erik Tollerud",
+			"Kyle Westfall"
 		],
         "deputy": ["Unfilled"],
         "role-head": "APE editor",


### PR DESCRIPTION
Establish responsibilities for the new [ape-editor-team](https://github.com/orgs/astropy/teams/ape-editor-team) as introduced by:

* https://github.com/astropy/astropy-APEs/pull/115

This should only be taken out of draft after https://github.com/astropy/astropy-APEs/pull/115 is merged.

It would be initially staffed by CoCo, though ideally it should be eventually handed off to other community members who volunteer following the process established for other roles.