### PR TITLE
Change names of listed "maintainer" for core package

### DIFF
--- a/affiliated/registry.json
+++ b/affiliated/registry.json
@@ -117,7 +117,7 @@
         },
         {
             "name": "astropy core package",
-            "maintainer": "Astropy Coordination Committee",
+            "maintainer": "Astropy Maintainer Community",
             "stable": true,
             "home_url": "https://docs.astropy.org",
             "repo_url": "https://github.com/astropy/astropy",


### PR DESCRIPTION
I think it's not (or at least no longer) accurate to describe the maintainer of the core packages as the "coordination committee". We have a larger number of maintainers for the core package that are not the the Coco, ad reversely, we have had (or cna have in the future) Coco members who are not maintainers of the code package.
    
Alternative wordings could be "core maintainers", but that's too self-refential as for an entry in "core package - maintainers", or it could be a link to the roles page, but I don't think it's worth setting that up here.
    
So, I suggest just this minimal change.

Found in #699
