### PR TITLE
Remove SAMP maintenance from Astropy Team

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -502,12 +502,6 @@
                 ]
             },
             {
-                "role": "astropy.samp",
-                "people": [
-                    "Unfilled"
-                ]
-            },
-            {
                 "role": "astropy.stats",
                 "people": [
                     "Larry Bradley"


### PR DESCRIPTION
astropy.samp is unmaintained to begin with and is deprecated in astropy v8.0.0. It is now pyvo.samp and maintained by pyvo team.

* https://github.com/astropy/pyvo/pull/729
* https://github.com/astropy/astropy/pull/19373

cc @astropy/coordinators 