### PR TITLE
Remove now suspicious link from Travis CI

### DIFF
--- a/history.rst
+++ b/history.rst
@@ -127,8 +127,8 @@ unglamorous but critical. Tasks include promptly labeling and
 triaging new issues, responding to new pull requests, and watching
 for and fixing changes that break part of the infrastructure.
 There have been times when that infrastructure has shifted very
-rapidly, such as when `Travis-CI stopped hosting open source
-packages <https://www.travis-ci.com/blog/2020-11-02-travis-ci-new-billing/>`__.
+rapidly, such as when Travis-CI stopped hosting open source
+packages in Nov 2020.
 Transitioning the entire ecosystem to a new infrastructure
 required substantial effort by a number of people, though it was
 facilitated primarily by a single individual. Indeed, much of this


### PR DESCRIPTION
The link chronically fails linkcheck now with "415 Client Error: Unsupported Media Type for url" and when I manually check the link, at one point, my antivirus blocked a malicious thingy or so it claimed. I don't think this URL is worth keeping.