### PR TITLE
Add Michael Coughlin as a co-maintainer of astropy-healpix

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -608,7 +608,8 @@
                 "role": "astropy-healpix",
                 "people": [
                     "Leo Singer",
-                    "Thomas Robitaille"
+                    "Thomas Robitaille",
+                    "Michael Coughlin"
                 ]
             },
             {


### PR DESCRIPTION
Prof. Michael Coughlin (@mcoughlin) is a professor at Unniversity of Minnesota, a longtime collaborator of mine, a heavy user of HEALPix, and the originator of several high quality recent issues and PRs for astropy-healpix.