### PR TITLE
Add Jason Grout to Finance Committee

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -92,8 +92,8 @@
         "url": "finance_committee_member",
         "people": [
             "Kelle Cruz (chair)",
+            "Jason Grout",
             "Aarya Patil",
-            "John Swinbank",
             "Erik Tollerud"
         ],
         "role-head": "Finance committee member",


### PR DESCRIPTION
At their request, the Coordination Committee sought out new members for the Finance Committee.  We nominated Jason Grout and he has agreed to the nomination and to follow the Astropy Code of Conduct.

This PR adds him to the Finance Committee and removes John Swinbank.  Please provide any feedback here!  Feedback will be closed on ~15 Sept and the CoCo will make a final decision on this change.